### PR TITLE
fix: sanitize ffprobe input parameters

### DIFF
--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/mediaanalyzer/MediaAnalyzerService.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/mediaanalyzer/MediaAnalyzerService.kt
@@ -32,6 +32,7 @@ import se.svt.oss.mediaanalyzer.mediainfo.MediaInfo
 import se.svt.oss.mediaanalyzer.mediainfo.OtherTrack
 import se.svt.oss.mediaanalyzer.mediainfo.TextTrack
 import se.svt.oss.mediaanalyzer.mediainfo.VideoTrack
+import java.util.concurrent.ConcurrentHashMap
 
 private val log = KotlinLogging.logger {}
 
@@ -54,15 +55,18 @@ private val log = KotlinLogging.logger {}
 )
 class MediaAnalyzerService(private val mediaAnalyzer: MediaAnalyzer) {
 
+    val ffprobeValidParams = getValidFfprobeParams();
+
     fun analyzeInput(input: Input) {
         log.debug { "Analyzing input $input" }
         val probeInterlaced = input is VideoIn && input.probeInterlaced
         val useFirstAudioStreams = (input as? AudioIn)?.channelLayout?.channels?.size
+        val ffprobeInputParams = LinkedHashMap(input.params.filterKeys { ffprobeValidParams.contains(it) })
 
         input.analyzed = mediaAnalyzer.analyze(
             file = input.accessUri,
             probeInterlaced = probeInterlaced,
-            ffprobeInputParams = input.params,
+            ffprobeInputParams = ffprobeInputParams,
         )
             .let {
                 val selectedVideoStream = (input as? VideoIn)?.videoStream
@@ -81,4 +85,23 @@ class MediaAnalyzerService(private val mediaAnalyzer: MediaAnalyzer) {
                 }
             }
     }
+}
+
+fun getValidFfprobeParams(): Set<String> {
+    val process = ProcessBuilder("ffprobe", "-h")
+        .redirectErrorStream(true)
+        .start()
+    val output = process.inputStream.bufferedReader().use { it.readText() }
+    val exitCode = process.waitFor()
+    if (exitCode != 0) {
+        log.error {"Failed to get valid ffprobe parameters, ffprobe failed with exit code: $exitCode"}
+        return emptySet();
+    }
+    val result = ConcurrentHashMap.newKeySet<String>()
+    output.lines().filter { it.startsWith("  -") || it.startsWith("-") }
+        .forEach { line ->
+            val param = line.substringAfter("-").substringBefore(" ")
+            result.add(param)
+        }
+    return result
 }


### PR DESCRIPTION
Any parameters from the job input.params are now only passed on to ffprobe if they are valid ffprobe parameters. fixes issue #34. (https://github.com/svt/encore/issues/34)