### PR TITLE
feat: add support for encoding audio separately without segmenting

### DIFF
--- a/checks.gradle
+++ b/checks.gradle
@@ -17,6 +17,8 @@ jacocoTestCoverageVerification {
                     '*QueueService.migrateQueues()',
                     '*.ShutdownHandler.*',
                     '*FfmpegExecutor.runFfmpeg$lambda$7(java.lang.Process)',
+                    '*FfmpegExecutor.runFfmpeg$lambda$8(java.lang.Process)',
+                    '*FfmpegExecutorKt.getProgressRegex()',
                     '*FilterSettings.*',
             ]
             limit {

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/config/EncodingProperties.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/config/EncodingProperties.kt
@@ -8,6 +8,10 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty
 import org.springframework.core.io.Resource
 import se.svt.oss.encore.model.profile.ChannelLayout
 
+data class SegmentedEncodingProperties(
+    val enabledForAudio: Boolean = true,
+)
+
 data class EncodingProperties(
     val audioMixPresetLocation: Resource? = null,
     @NestedConfigurationProperty
@@ -17,4 +21,6 @@ data class EncodingProperties(
     val flipWidthHeightIfPortrait: Boolean = true,
     val exitOnError: Boolean = true,
     val globalParams: LinkedHashMap<String, Any?> = linkedMapOf(),
+    @NestedConfigurationProperty
+    val segmentedEncoding: SegmentedEncodingProperties = SegmentedEncodingProperties(),
 )

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/EncoreJob.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/EncoreJob.kt
@@ -21,6 +21,35 @@ import se.svt.oss.mediaanalyzer.file.MediaFile
 import java.time.OffsetDateTime
 import java.util.UUID
 
+data class SegmentedEncodingInfo(
+    @Schema(
+        description = "Length of each segment in seconds. Should be a multiple of target GOP.",
+        example = "19.2",
+        readOnly = true,
+        nullable = false,
+    )
+    val segmentLength: Double,
+    @Schema(
+        description = "Number of segments",
+        nullable = false,
+        readOnly = true,
+    )
+    val numSegments: Int,
+    @Schema(
+        description = "Number of encoding tasks used for this job. This is either the number of segments, or the number of segments + 1 if separate audio encode is used.",
+        nullable = false,
+        readOnly = true,
+    )
+    val numTasks: Int,
+    @Schema(
+        description = "Indicates if audio is encoded in segments. Otherwise a separate task will be used to encode the full audio.",
+        example = "true",
+        nullable = false,
+        readOnly = true,
+    )
+    val segmentedAudioEncode: Boolean,
+)
+
 @Validated
 @RedisHash("encore-jobs", timeToLive = (60 * 60 * 24 * 7).toLong()) // 1 week ttl
 @Tag(name = "encorejob")
@@ -106,6 +135,21 @@ data class EncoreJob(
     )
     @Positive
     val segmentLength: Double? = null,
+
+    @Schema(
+        description = "If true, and segmented encoding i used, audio will be encoded in segments. Otherwise a separate task will be used to encode the full audio.",
+        example = "true",
+        defaultValue = "true",
+        nullable = true,
+    )
+    val segmentedEncodingEnabledForAudio: Boolean? = null,
+
+    @Schema(
+        description = "Properties for segmented encoding, or null if not used",
+        nullable = true,
+        readOnly = true,
+    )
+    var segmentedEncodingInfo: SegmentedEncodingInfo? = null,
 
     @Schema(
         description = "The exception message, if the EncoreJob failed",

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/queue/QueueItem.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/queue/QueueItem.kt
@@ -14,5 +14,17 @@ data class QueueItem(
     val id: String,
     val priority: Int = 0,
     val created: LocalDateTime = LocalDateTime.now(),
-    val segment: Int? = null,
+    val task: Task? = null,
+)
+
+enum class TaskType {
+    AUDIOVIDEOSEGMENT,
+    VIDEOSEGMENT,
+    AUDIOFULL,
+}
+
+data class Task(
+    val type: TaskType,
+    val taskNo: Int,
+    val segment: Int,
 )

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/process/SegmentUtil.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/process/SegmentUtil.kt
@@ -10,7 +10,9 @@ import kotlin.math.ceil
 
 fun EncoreJob.segmentLengthOrThrow() = segmentLength ?: throw RuntimeException("No segmentLength in job!")
 
-fun EncoreJob.numSegments(): Int {
+fun EncoreJob.segmentedEncodingInfoOrThrow() = segmentedEncodingInfo ?: throw RuntimeException("No segmentedEncodingInfo in job!")
+
+fun EncoreJob.numVideoSegments(): Int {
     val segLen = segmentLengthOrThrow()
     val readDuration = duration
     return if (readDuration != null) {
@@ -24,10 +26,9 @@ fun EncoreJob.numSegments(): Int {
         segments.first()
     }
 }
-
 fun EncoreJob.segmentDuration(segmentNumber: Int): Double = when {
     duration == null -> segmentLengthOrThrow()
-    segmentNumber < numSegments() - 1 -> segmentLengthOrThrow()
+    segmentNumber < numVideoSegments() - 1 -> segmentLengthOrThrow()
     else -> duration!! % segmentLengthOrThrow()
 }
 

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/EncoreService.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/EncoreService.kt
@@ -34,12 +34,16 @@ import se.svt.oss.encore.config.EncoreProperties
 import se.svt.oss.encore.model.EncoreJob
 import se.svt.oss.encore.model.RedisEvent
 import se.svt.oss.encore.model.SegmentProgressEvent
+import se.svt.oss.encore.model.SegmentedEncodingInfo
 import se.svt.oss.encore.model.Status
 import se.svt.oss.encore.model.queue.QueueItem
+import se.svt.oss.encore.model.queue.Task
+import se.svt.oss.encore.model.queue.TaskType
 import se.svt.oss.encore.process.baseName
-import se.svt.oss.encore.process.numSegments
+import se.svt.oss.encore.process.numVideoSegments
 import se.svt.oss.encore.process.segmentDuration
 import se.svt.oss.encore.process.segmentLengthOrThrow
+import se.svt.oss.encore.process.segmentedEncodingInfoOrThrow
 import se.svt.oss.encore.repository.EncoreJobRepository
 import se.svt.oss.encore.service.callback.CallbackService
 import se.svt.oss.encore.service.localencode.LocalEncodeService
@@ -49,7 +53,9 @@ import se.svt.oss.encore.service.remotefiles.RemoteFileService
 import se.svt.oss.mediaanalyzer.file.MediaContainer
 import se.svt.oss.mediaanalyzer.file.MediaFile
 import java.io.File
+import java.nio.file.Paths
 import java.util.Locale
+import kotlin.io.path.isDirectory
 import kotlin.time.TimedValue
 import kotlin.time.measureTimedValue
 
@@ -82,7 +88,7 @@ class EncoreService(
 
     fun encode(queueItem: QueueItem, job: EncoreJob) {
         when {
-            queueItem.segment != null -> encodeSegment(job, queueItem.segment)
+            queueItem.task != null -> encodeSegment(job, queueItem.task)
             job.segmentLength != null -> encodeSegmented(job)
             else -> encode(job)
         }
@@ -94,21 +100,53 @@ class EncoreService(
         var progressListener: SegmentProgressListener? = null
         try {
             initJob(encoreJob)
-            val numSegments = encoreJob.numSegments()
+
+            val segmentedEncodingInfo = encoreJob.segmentedEncodingInfoOrThrow()
+
+            val separateAudioEncode = !segmentedEncodingInfo.segmentedAudioEncode
+            val numSegments = segmentedEncodingInfo.numSegments
+            val numTasks = segmentedEncodingInfo.numTasks
+
             log.debug { "Encoding using $numSegments segments" }
+            if (separateAudioEncode) {
+                log.debug { "Encoding audio separately" }
+            }
             redisMessageListerenerContainer.addMessageListener(cancelListener, ChannelTopic.of(cancelTopicName))
             val progressChannel = Channel<Int>()
             progressListener =
-                SegmentProgressListener(objectMapper, encoreJob.id, coroutineJob, numSegments, progressChannel)
+                SegmentProgressListener(objectMapper, encoreJob.id, coroutineJob, numTasks, progressChannel)
             redisMessageListerenerContainer.addMessageListener(progressListener, ChannelTopic.of("segment-progress"))
             val timedOutput = measureTimedValue {
                 sharedWorkDir(encoreJob).mkdirs()
+                var taskNo = 0
+                if (separateAudioEncode) {
+                    queueService.enqueue(
+                        QueueItem(
+                            id = encoreJob.id.toString(),
+                            priority = encoreJob.priority,
+                            task = Task(
+                                type = TaskType.AUDIOFULL,
+                                taskNo = taskNo++,
+                                segment = 0,
+                            ),
+                        ),
+                    )
+                }
+                val segmentsTaskType = if (separateAudioEncode) {
+                    TaskType.VIDEOSEGMENT
+                } else {
+                    TaskType.AUDIOVIDEOSEGMENT
+                }
                 repeat(numSegments) {
                     queueService.enqueue(
                         QueueItem(
                             id = encoreJob.id.toString(),
                             priority = encoreJob.priority,
-                            segment = it,
+                            task = Task(
+                                type = segmentsTaskType,
+                                taskNo = taskNo++,
+                                segment = it,
+                            ),
                         ),
                     )
                 }
@@ -119,7 +157,7 @@ class EncoreService(
                         progressChannel.trySendBlocking(0)
                         while (!progressListener.completed()) {
                             ShutdownHandler.checkShutdown()
-                            log.info { "Awaiting completion ${progressListener.completionCount()}/$numSegments..." }
+                            log.info { "Awaiting completion ${progressListener.completionCount()}/$numTasks..." }
                             delay(1000)
                         }
                     }
@@ -132,7 +170,9 @@ class EncoreService(
                 val suffixes = mutableSetOf<String>()
                 repeat(numSegments) { segmentNum ->
                     val segmentBaseName = encoreJob.baseName(segmentNum)
-                    outWorkDir.list()?.filter { it.startsWith(segmentBaseName) }
+                    outWorkDir.list()
+                        ?.filter { !Paths.get(it).isDirectory() }
+                        ?.filter { it.startsWith(segmentBaseName) }
                         ?.forEach {
                             val suffix = it.replaceFirst(segmentBaseName, "")
                             suffixes.add(suffix)
@@ -141,13 +181,34 @@ class EncoreService(
                 }
                 val outputFolder = File(encoreJob.outputFolder)
                 outputFolder.mkdirs()
+                val audioFilesMap: MutableMap<String, File> = if (separateAudioEncode) {
+                    sharedWorkDir(encoreJob).resolve("audio")
+                        .listFiles()
+                        ?.filter { it.isFile }
+                        ?.associateBy { it.name }
+                        ?.toMutableMap()
+                        ?: mutableMapOf()
+                } else {
+                    mutableMapOf()
+                }
                 val outputFiles = suffixes.map {
                     val targetName = encoreJob.baseName + it
                     log.info { "Joining segments for $targetName" }
                     val targetFile = outputFolder.resolve(targetName)
-                    ffmpegExecutor.joinSegments(encoreJob, outWorkDir.resolve("$it.txt"), targetFile)
+                    val audioFile = audioFilesMap.remove(targetName)
+                    ffmpegExecutor.joinSegments(encoreJob, outWorkDir.resolve("$it.txt"), targetFile, audioFile)
                 }
-                outputFiles
+                val audioOnlyOutputFiles = if (separateAudioEncode) {
+                    audioFilesMap.values.map {
+                        log.info { "Moving audio file ${it.name} to output folder" }
+                        val target = outputFolder.resolve(it.name)
+                        it.copyTo(target, overwrite = true)
+                        mediaAnalyzerService.analyze(target.absolutePath)
+                    }
+                } else {
+                    emptyList()
+                }
+                outputFiles + audioOnlyOutputFiles
             }
             updateSuccessfulJob(encoreJob, timedOutput)
         } catch (e: CancellationException) {
@@ -167,25 +228,36 @@ class EncoreService(
         }
     }
 
-    private fun encodeSegment(encoreJob: EncoreJob, segmentNumber: Int) {
+    private fun encodeSegment(encoreJob: EncoreJob, task: Task) {
+        val taskNo = task.taskNo
         try {
-            log.info { "Start encoding ${encoreJob.baseName} segment $segmentNumber/${encoreJob.numSegments()} " }
-            val outputFolder = sharedWorkDir(encoreJob).absolutePath
-            val job = encoreJob.copy(
-                baseName = encoreJob.baseName(segmentNumber),
-                duration = encoreJob.segmentDuration(segmentNumber),
-                inputs = encoreJob.inputs.map {
-                    it.withSeekTo((it.seekTo ?: 0.0) + encoreJob.segmentLengthOrThrow() * segmentNumber)
-                },
-            )
-            ffmpegExecutor.run(job, outputFolder, null)
-            redisTemplate.convertAndSend("segment-progress", SegmentProgressEvent(encoreJob.id, segmentNumber, true))
-            log.info { "Completed ${encoreJob.baseName} segment $segmentNumber/${encoreJob.numSegments()} " }
+            log.info { "Start encoding ${encoreJob.baseName} task $taskNo/${encoreJob.segmentedEncodingInfo?.numTasks} (${task.type})" }
+            val encodingMode = when (task.type) {
+                TaskType.AUDIOFULL -> EncodingMode.AUDIO_ONLY
+                TaskType.VIDEOSEGMENT -> EncodingMode.VIDEO_ONLY
+                TaskType.AUDIOVIDEOSEGMENT -> EncodingMode.AUDIO_AND_VIDEO
+            }
+            val (job, outputFolder) = if (encodingMode == EncodingMode.AUDIO_ONLY) {
+                Pair(encoreJob, sharedWorkDir(encoreJob).resolve("audio").absolutePath)
+            } else {
+                val segmentNumber = task.segment
+                val job = encoreJob.copy(
+                    baseName = encoreJob.baseName(segmentNumber),
+                    duration = encoreJob.segmentDuration(segmentNumber),
+                    inputs = encoreJob.inputs.map {
+                        it.withSeekTo((it.seekTo ?: 0.0) + encoreJob.segmentLengthOrThrow() * segmentNumber)
+                    },
+                )
+                Pair(job, sharedWorkDir(encoreJob).absolutePath)
+            }
+            ffmpegExecutor.run(job, outputFolder, null, encodingMode)
+            redisTemplate.convertAndSend("segment-progress", SegmentProgressEvent(encoreJob.id, taskNo, true))
+            log.info { "Completed ${encoreJob.baseName} task $taskNo/${encoreJob.segmentedEncodingInfo?.numTasks} " }
         } catch (e: ApplicationShutdownException) {
             throw e
         } catch (e: Exception) {
-            log.error(e) { "Error encoding segment $segmentNumber: ${e.message}" }
-            redisTemplate.convertAndSend("segment-progress", SegmentProgressEvent(encoreJob.id, segmentNumber, false))
+            log.error(e) { "Error encoding task $taskNo: ${e.message}" }
+            redisTemplate.convertAndSend("segment-progress", SegmentProgressEvent(encoreJob.id, taskNo, false))
         }
     }
 
@@ -278,6 +350,18 @@ class EncoreService(
 
         encoreJob.inputs.forEach { input ->
             mediaAnalyzerService.analyzeInput(input)
+        }
+        if (encoreJob.segmentLength != null) {
+            val segmentedAudioEncode: Boolean = encoreJob.segmentedEncodingEnabledForAudio
+                ?: encoreProperties.encoding.segmentedEncoding.enabledForAudio
+            val numSegments = encoreJob.numVideoSegments()
+            val numTasks = numSegments + if (segmentedAudioEncode) 0 else 1
+            encoreJob.segmentedEncodingInfo = SegmentedEncodingInfo(
+                segmentLength = encoreJob.segmentLengthOrThrow(),
+                segmentedAudioEncode = segmentedAudioEncode,
+                numTasks = numTasks,
+                numSegments = numSegments,
+            )
         }
         log.info { "Start encoding" }
         encoreJob.status = Status.IN_PROGRESS

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/FfmpegExecutor.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/FfmpegExecutor.kt
@@ -12,6 +12,7 @@ import se.svt.oss.encore.config.EncoreProperties
 import se.svt.oss.encore.model.EncoreJob
 import se.svt.oss.encore.model.input.maxDuration
 import se.svt.oss.encore.model.mediafile.toParams
+import se.svt.oss.encore.model.output.Output
 import se.svt.oss.encore.process.CommandBuilder
 import se.svt.oss.encore.process.createTempDir
 import se.svt.oss.encore.service.audiomix.AudioMixPresetService
@@ -25,6 +26,27 @@ import kotlin.math.round
 
 private val log = KotlinLogging.logger { }
 
+enum class EncodingMode {
+    AUDIO_AND_VIDEO,
+    VIDEO_ONLY,
+    AUDIO_ONLY,
+}
+
+val progressRegex =
+    Regex(".*time=(?<hours>\\d{2}):(?<minutes>\\d{2}):(?<seconds>\\d{2}\\.\\d+) .* speed= *(?<speed>[0-9.e-]+x) *")
+
+fun getProgress(duration: Double?, line: String): Int? = if (duration != null && duration > 0) {
+    progressRegex.matchEntire(line)?.let {
+        val hours = it.groups["hours"]!!.value.toInt()
+        val minutes = it.groups["minutes"]!!.value.toInt()
+        val seconds = it.groups["seconds"]!!.value.toDouble()
+        val time = hours * 3600 + minutes * 60 + seconds
+        min(100, round(100 * time / duration).toInt())
+    }
+} else {
+    null
+}
+
 @Service
 class FfmpegExecutor(
     private val mediaAnalyzer: MediaAnalyzer,
@@ -37,13 +59,11 @@ class FfmpegExecutor(
 
     fun getLoglevel(line: String) = logLevelRegex.matchEntire(line)?.groups?.get("level")?.value
 
-    val progressRegex =
-        Regex(".*time=(?<hours>\\d{2}):(?<minutes>\\d{2}):(?<seconds>\\d{2}\\.\\d+) .* speed= *(?<speed>[0-9.e-]+x) *")
-
     fun run(
         encoreJob: EncoreJob,
         outputFolder: String,
         progressChannel: SendChannel<Int>?,
+        encodingMode: EncodingMode = EncodingMode.AUDIO_AND_VIDEO,
     ): List<MediaFile> {
         ShutdownHandler.checkShutdown()
         val profile = profileService.getProfile(encoreJob)
@@ -56,7 +76,7 @@ class FfmpegExecutor(
                 encodingProperties,
                 profile.filterSettings,
             )
-        }
+        }.mapNotNull { adaptOutputToEncodingMode(it, encodingMode) }
 
         check(outputs.distinctBy { it.id }.size == outputs.size) {
             "Profile ${encoreJob.profile} contains duplicate suffixes: ${outputs.map { it.id }}!"
@@ -81,6 +101,23 @@ class FfmpegExecutor(
         } finally {
             workDir.deleteRecursively()
         }
+    }
+
+    private fun adaptOutputToEncodingMode(output: Output, encodingMode: EncodingMode): Output? = when (encodingMode) {
+        EncodingMode.AUDIO_AND_VIDEO -> output
+        EncodingMode.VIDEO_ONLY ->
+            if (output.video == null) {
+                null
+            } else {
+                output.copy(audioStreams = emptyList())
+            }
+
+        EncodingMode.AUDIO_ONLY ->
+            if (output.audioStreams.isEmpty()) {
+                null
+            } else {
+                output.copy(video = null)
+            }
     }
 
     private fun runFfmpeg(
@@ -169,20 +206,15 @@ class FfmpegExecutor(
     private fun totalProgress(subtaskProgress: Int, subtaskIndex: Int, subtaskCount: Int) =
         (subtaskIndex * 100 + subtaskProgress) / subtaskCount
 
-    private fun getProgress(duration: Double?, line: String): Int? = if (duration != null && duration > 0) {
-        progressRegex.matchEntire(line)?.let {
-            val hours = it.groups["hours"]!!.value.toInt()
-            val minutes = it.groups["minutes"]!!.value.toInt()
-            val seconds = it.groups["seconds"]!!.value.toDouble()
-            val time = hours * 3600 + minutes * 60 + seconds
-            min(100, round(100 * time / duration).toInt())
-        }
-    } else {
-        null
-    }
-
-    fun joinSegments(encoreJob: EncoreJob, segmentList: File, targetFile: File): MediaFile {
+    fun joinSegments(encoreJob: EncoreJob, segmentList: File, targetFile: File, audioFile: File?): MediaFile {
         val joinParams = profileService.getProfile(encoreJob).joinSegmentParams.toParams()
+        val inputArgs = mutableListOf("-i", "$segmentList")
+        val mapArgs = mutableListOf("-map", "0")
+        if (audioFile != null) {
+            inputArgs.addAll(listOf("-i", audioFile.absolutePath))
+            mapArgs.addAll(listOf("-map", "1"))
+        }
+
         val command = listOf(
             "ffmpeg",
             "-hide_banner",
@@ -193,10 +225,8 @@ class FfmpegExecutor(
             "concat",
             "-safe",
             "0",
-            "-i",
-            "$segmentList",
-            "-map",
-            "0",
+            *inputArgs.toTypedArray(),
+            *mapArgs.toTypedArray(),
             "-ignore_unknown",
             "-c",
             "copy",

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/mediaanalyzer/MediaAnalyzerService.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/mediaanalyzer/MediaAnalyzerService.kt
@@ -23,6 +23,7 @@ import se.svt.oss.mediaanalyzer.ffprobe.UnknownSideData
 import se.svt.oss.mediaanalyzer.ffprobe.UnknownStream
 import se.svt.oss.mediaanalyzer.file.AudioFile
 import se.svt.oss.mediaanalyzer.file.ImageFile
+import se.svt.oss.mediaanalyzer.file.MediaFile
 import se.svt.oss.mediaanalyzer.file.SubtitleFile
 import se.svt.oss.mediaanalyzer.file.VideoFile
 import se.svt.oss.mediaanalyzer.mediainfo.AudioTrack
@@ -85,6 +86,12 @@ class MediaAnalyzerService(private val mediaAnalyzer: MediaAnalyzer) {
                 }
             }
     }
+
+    fun analyze(
+        file: String,
+    ): MediaFile = mediaAnalyzer.analyze(
+        file = file,
+    )
 }
 
 fun getValidFfprobeParams(): Set<String> {

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/queue/QueueService.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/queue/QueueService.kt
@@ -54,7 +54,7 @@ class QueueService(
             log.info { "Job was cancelled" }
             return true
         }
-        if (queueItem.segment != null && job.status == Status.FAILED) {
+        if (queueItem.task != null && job.status == Status.FAILED) {
             log.info { "Main job has failed" }
             return true
         }
@@ -91,13 +91,13 @@ class QueueService(
         try {
             log.info { "Adding job to queue (repost on interrupt)" }
             enqueue(queueItem)
-            if (queueItem.segment == null) {
+            if (queueItem.task == null) {
                 job.status = Status.QUEUED
                 repository.save(job)
             }
             log.info { "Added job to queue (repost on interrupt)" }
         } catch (e: Exception) {
-            if (queueItem.segment == null) {
+            if (queueItem.task == null) {
                 val message = "Failed to add interrupted job to queue"
                 log.error(e) { message }
                 job.message = message

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/process/SegmentUtilTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/process/SegmentUtilTest.kt
@@ -35,7 +35,7 @@ class SegmentUtilTest {
             encoreJob.segmentLengthOrThrow()
         }.hasMessage(message)
         assertThatThrownBy {
-            encoreJob.numSegments()
+            encoreJob.numVideoSegments()
         }.hasMessage(message)
         assertThatThrownBy {
             encoreJob.segmentDuration(1)
@@ -48,20 +48,20 @@ class SegmentUtilTest {
     }
 
     @Test
-    fun numSegmentsDurationSet() {
+    fun numVideoSegmentsDurationSet() {
         val encoreJob = job.copy(duration = 125.0)
-        assertThat(encoreJob.numSegments()).isEqualTo(7)
+        assertThat(encoreJob.numVideoSegments()).isEqualTo(7)
     }
 
     @Test
-    fun numSegmentsDurationNotSet() {
-        assertThat(job.numSegments()).isEqualTo(141)
+    fun numVideoSegmentsDurationNotSet() {
+        assertThat(job.numVideoSegments()).isEqualTo(141)
     }
 
     @Test
-    fun numSegmentsInputsDiffer() {
+    fun numVideoSegmentsInputsDiffer() {
         val encoreJob = job.copy(inputs = job.inputs + AudioVideoInput(uri = "test", analyzed = defaultVideoFile))
-        assertThatThrownBy { encoreJob.numSegments() }
+        assertThatThrownBy { encoreJob.numVideoSegments() }
             .hasMessage("Inputs differ in length")
     }
 

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/service/FfmpegExecutorTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/service/FfmpegExecutorTest.kt
@@ -1,0 +1,38 @@
+package se.svt.oss.encore.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class FfmpegExecutorTest {
+    @Nested
+    inner class TestGetProgress {
+        @Test
+        fun `valid time and duration, returns progress`() {
+            val logLine = "frame=  240 fps= 24 q=28.0 size=    1024kB time=00:00:10.00 bitrate= 838.9kbits/s speed=1.00x"
+            val duration = 20.0 // seconds
+            val progress = getProgress(duration, logLine)
+            assertNotNull(progress)
+            assertEquals(50, progress)
+        }
+
+        @Test
+        fun `invalid logline, returns null`() {
+            val logLine = "RANDOM LOG LINE"
+            val duration = 20.0 // seconds
+            val progress = getProgress(duration, logLine)
+            assertNull(progress)
+        }
+
+        @Test
+        fun `null duration, returns null`() {
+            val logLine =
+                "frame=  240 fps= 24 q=28.0 size=    1024kB time=00:00:10.00 bitrate= 838.9kbits/s speed=1.00x"
+            val duration: Double? = null
+            val progress = getProgress(duration, logLine)
+            assertNull(progress)
+        }
+    }
+}

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/service/mediaanalyzer/MediaAnalyzerServiceTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/service/mediaanalyzer/MediaAnalyzerServiceTest.kt
@@ -1,0 +1,25 @@
+package se.svt.oss.encore.service.mediaanalyzer
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import se.svt.oss.mediaanalyzer.MediaAnalyzer
+import se.svt.oss.mediaanalyzer.file.MediaFile
+
+class MediaAnalyzerServiceTest {
+    private val mediaAnalyzer = mockk<MediaAnalyzer>()
+
+    private val mediaAnalyzerService = MediaAnalyzerService(mediaAnalyzer)
+
+    @Test
+    fun testAnalyze() {
+        val mediaFile = mockk<MediaFile>()
+        val slot = io.mockk.slot<String>()
+        every { mediaAnalyzer.analyze(capture(slot)) } returns mediaFile
+
+        val actual = mediaAnalyzerService.analyze("testInput")
+        assertEquals(mediaFile, actual)
+        assertEquals("testInput", slot.captured)
+    }
+}

--- a/encore-common/src/test/resources/profile/profiles.yml
+++ b/encore-common/src/test/resources/profile/profiles.yml
@@ -6,4 +6,5 @@ archive: archive.yml
 audio-streams: audio-streams.yml
 test-invalid: test_profile_invalid.yml
 test-invalid-location: test_profile_invalid_location.yml
+separate-video-audio: separate-video-audio.yml
 none:

--- a/encore-common/src/test/resources/profile/separate-video-audio.yml
+++ b/encore-common/src/test/resources/profile/separate-video-audio.yml
@@ -1,0 +1,51 @@
+name: separate-video-audio
+description: Testing profile with one video/audio output and multiple audio only outputs
+scaling: bicubic
+encodes:
+  - type: X264Encode
+    suffix: _x264_3100
+    twoPass: true
+    height: 1080
+    params:
+      b:v: 3100k
+      maxrate: 4700k
+      bufsize: 6200k
+      r: 25
+      fps_mode: cfr
+      pix_fmt: yuv420p
+      force_key_frames: expr:not(mod(n,96))
+      profile:v: high
+      level: 4.1
+    audioEncode:
+      type: AudioEncode
+      bitrate: 128k
+      suffix: STEREO
+
+  - type: AudioEncode
+    bitrate: 128k
+    suffix: _STEREO
+
+  - type: AudioEncode
+    bitrate: 128k
+    suffix: _STEREO_DE
+    dialogueEnhancement:
+      enabled: true
+    audioMixPreset: de
+    optional: true
+
+  - type: AudioEncode
+    codec: ac3
+    bitrate: 448k
+    suffix: _SURROUND
+    optional: true
+    channelLayout: '5.1'
+
+  - type: AudioEncode
+    codec: ac3
+    bitrate: 448k
+    suffix: _SURROUND_DE
+    dialogueEnhancement:
+      enabled: true
+    audioMixPreset: de
+    optional: true
+    channelLayout: '5.1'


### PR DESCRIPTION
add support for encoding audio separately without segmenting when using segmented encoding

This feature can be enabled for a job by setting 'segmentedEncodingEnabledForAudio' to 'false' for the job. If this property is not set for a job, the default value from the configuration property 'encore-settings.encoding.segmentedEncoding.enabledForAudio' will be used. This property defaults to false, which means the default behavior is to use segemented encoding also for audio.

Refs: #41