### PR TITLE
fix: regex for parsing progress now works for ffmpeg 8

### DIFF
--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/FfmpegExecutor.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/FfmpegExecutor.kt
@@ -33,7 +33,7 @@ enum class EncodingMode {
 }
 
 val progressRegex =
-    Regex(".*time=(?<hours>\\d{2}):(?<minutes>\\d{2}):(?<seconds>\\d{2}\\.\\d+) .* speed= *(?<speed>[0-9.e-]+x) *")
+    Regex(".*time=(?<hours>\\d{2}):(?<minutes>\\d{2}):(?<seconds>\\d{2}\\.\\d+) .* speed= *(?<speed>[0-9.e-]+x).*")
 
 fun getProgress(duration: Double?, line: String): Int? = if (duration != null && duration > 0) {
     progressRegex.matchEntire(line)?.let {

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/service/FfmpegExecutorTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/service/FfmpegExecutorTest.kt
@@ -19,6 +19,15 @@ class FfmpegExecutorTest {
         }
 
         @Test
+        fun `logline with elapsed on end`() {
+            val logLine = "[info] frame= 2896 fps= 75 q=27.0 size=   35328KiB time=00:01:55.76 bitrate=2500.1kbits/s dup=118 drop=0 speed=3.01x elapsed=0:00:38.51"
+            val duration = 2894.0
+            val progress = getProgress(duration, logLine)
+            assertNotNull(progress)
+            assertEquals(4, progress)
+        }
+
+        @Test
         fun `invalid logline, returns null`() {
             val logLine = "RANDOM LOG LINE"
             val duration = 20.0 // seconds


### PR DESCRIPTION
ffmpeg 8.0 has an additional field 'elapsed' added to the end of the progress output line, which causes the regex for parsing to fail.