### PR TITLE
feat: add support for configuration properties for multipart upload

### DIFF
--- a/encore-common/src/main/kotlin/se/svt/oss/encore/S3RemoteFilesConfiguration.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/S3RemoteFilesConfiguration.kt
@@ -39,10 +39,16 @@ class S3RemoteFilesConfiguration {
     fun s3Client(s3Region: Region, s3Properties: S3Properties) = S3AsyncClient.builder()
         .region(s3Region)
         .crossRegionAccessEnabled(true)
+        .multipartConfiguration { multipartConfigurationBuilder ->
+            multipartConfigurationBuilder
+                .minimumPartSizeInBytes(s3Properties.multipart.minimumPartSize)
+                .thresholdInBytes(s3Properties.multipart.threshold)
+                .apiCallBufferSizeInBytes(s3Properties.multipart.apiCallBufferSize)
+        }
         .multipartEnabled(!s3Properties.anonymousAccess) // Multipart upload requires credentials
         .serviceConfiguration(
             S3Configuration.builder()
-                .pathStyleAccessEnabled(true)
+                .pathStyleAccessEnabled(s3Properties.usePathStyle)
                 .build(),
         )
         .credentialsProvider(

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/remotefiles/s3/S3Properties.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/remotefiles/s3/S3Properties.kt
@@ -5,14 +5,25 @@
 package se.svt.oss.encore.service.remotefiles.s3
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.NestedConfigurationProperty
 import java.time.Duration
+
+const val MB = 1024 * 1024L
+
+data class MultipartUploadProperties(
+    val minimumPartSize: Long = 8 * MB,
+    val threshold: Long = 8 * MB,
+    val apiCallBufferSize: Long = 32 * MB,
+)
 
 @ConfigurationProperties("remote-files.s3")
 data class S3Properties(
     val enabled: Boolean = false,
     val anonymousAccess: Boolean = false,
-    val usePathStyle: Boolean = false,
+    val usePathStyle: Boolean = true,
     val endpoint: String = "",
     val presignDurationSeconds: Long = Duration.ofHours(12).seconds,
     val uploadTimeoutSeconds: Long = Duration.ofHours(1).seconds,
+    @NestedConfigurationProperty
+    val multipart: MultipartUploadProperties = MultipartUploadProperties(),
 )

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/service/remotefiles/s3/S3UriConverterTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/service/remotefiles/s3/S3UriConverterTest.kt
@@ -41,7 +41,7 @@ class S3UriConverterTest {
             val s3UriConverter = S3UriConverter(s3Properties.copy(endpoint = endpoint), region)
 
             val httpUri = s3UriConverter.toHttp(s3Uri)
-            assertThat(httpUri).isEqualTo("https://my-bucket.some-host:1234/test2/test1_x264_3100.mp4")
+            assertThat(httpUri).isEqualTo("https://some-host:1234/my-bucket/test2/test1_x264_3100.mp4")
         }
 
         @Test
@@ -50,16 +50,16 @@ class S3UriConverterTest {
             val s3UriConverter = S3UriConverter(s3Properties.copy(endpoint = endpoint), region)
 
             val httpUri = s3UriConverter.toHttp(s3Uri)
-            assertThat(httpUri).isEqualTo("https://my-bucket.some-host/test2/test1_x264_3100.mp4")
+            assertThat(httpUri).isEqualTo("https://some-host/my-bucket/test2/test1_x264_3100.mp4")
         }
 
         @Test
-        fun customEndpointReturnsCorrectPathStyleUri() {
+        fun customEndpointReturnsCorrectHostStyleUri() {
             val endpoint = "http://some-host:1234"
-            val s3UriConverter = S3UriConverter(s3Properties.copy(endpoint = endpoint, usePathStyle = true), region)
+            val s3UriConverter = S3UriConverter(s3Properties.copy(endpoint = endpoint, usePathStyle = false), region)
 
             val httpUri = s3UriConverter.toHttp(s3Uri)
-            assertThat(httpUri).isEqualTo("http://some-host:1234/my-bucket/test2/test1_x264_3100.mp4")
+            assertThat(httpUri).isEqualTo("http://my-bucket.some-host:1234/test2/test1_x264_3100.mp4")
         }
 
         @Test


### PR DESCRIPTION
S3 multipart upload can now be configured through configuration properties:
- remote-files.s3.multipart.minimumPartSize
- remote-files.s3.multipartthreshold
- remote-files.s3.multipart.apicallbuffersize

These properties corresponds to the properties in
software.amazon.awssdk.services.s3.multipart.MultipartConfiguration See https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/multipart/MultipartConfiguration.html