### PR TITLE
Segmented audio encode

### DIFF
--- a/checks.gradle
+++ b/checks.gradle
@@ -19,6 +19,7 @@ jacocoTestCoverageVerification {
                     '*FfmpegExecutor.runFfmpeg$lambda$?(java.lang.Process)',
                     '*FfmpegExecutorKt.getProgressRegex()',
                     '*FilterSettings.*',
+                    'se.svt.oss.encore.service.EncoreService.handleProgress.1.1.emit(int, kotlin.coroutines.Continuation)',
             ]
             limit {
                 counter = 'LINE'

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/config/EncodingProperties.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/config/EncodingProperties.kt
@@ -6,10 +6,11 @@ package se.svt.oss.encore.config
 
 import org.springframework.boot.context.properties.NestedConfigurationProperty
 import org.springframework.core.io.Resource
+import se.svt.oss.encore.model.AudioEncodingMode
 import se.svt.oss.encore.model.profile.ChannelLayout
 
 data class SegmentedEncodingProperties(
-    val enabledForAudio: Boolean = true,
+    val audioEncodingMode: AudioEncodingMode = AudioEncodingMode.ENCODE_WITH_VIDEO,
 )
 
 data class EncodingProperties(

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/AudioEncodingMode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/AudioEncodingMode.kt
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 Eyevinn Technology AB
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.svt.oss.encore.model
+
+/**
+ * Defines how audio should be encoded when using segmented encoding.
+ */
+enum class AudioEncodingMode {
+    /**
+     * Encode audio and video together in the same segments.
+     * Creates N tasks of type AUDIOVIDEOSEGMENT.
+     */
+    ENCODE_WITH_VIDEO,
+
+    /**
+     * Encode audio separately from video as a single full-length file (not segmented).
+     * Creates 1 AUDIOFULL task + N VIDEOSEGMENT tasks.
+     */
+    ENCODE_SEPARATELY_FULL,
+
+    /**
+     * Encode audio separately from video, with both audio and video segmented.
+     * Creates N AUDIOSEGMENT tasks + N VIDEOSEGMENT tasks (2N total tasks).
+     */
+    ENCODE_SEPARATELY_SEGMENTED,
+}

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/EncoreJob.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/EncoreJob.kt
@@ -30,24 +30,44 @@ data class SegmentedEncodingInfo(
     )
     val segmentLength: Double,
     @field:Schema(
-        description = "Number of segments",
+        description = "Number of video segments",
         nullable = false,
         readOnly = true,
     )
     val numSegments: Int,
     @field:Schema(
-        description = "Number of encoding tasks used for this job. This is either the number of segments, or the number of segments + 1 if separate audio encode is used.",
+        description = "Number of encoding tasks used for this job. This will be equal to numSegments plus numAudioSegments",
         nullable = false,
         readOnly = true,
     )
     val numTasks: Int,
     @field:Schema(
-        description = "Indicates if audio is encoded in segments. Otherwise a separate task will be used to encode the full audio.",
-        example = "true",
+        description = "The audio encoding mode used for this job.",
+        example = "ENCODE_WITH_VIDEO",
         nullable = false,
         readOnly = true,
     )
-    val segmentedAudioEncode: Boolean,
+    val audioEncodingMode: AudioEncodingMode,
+    @field:Schema(
+        description = "Audio segment padding in seconds (added at start/end of segments to avoid artifacts). Only relevant in ENCODE_SEPARATELY_SEGMENTED mode.",
+        example = "0.04267",
+        nullable = false,
+        readOnly = true,
+    )
+    val audioSegmentPadding: Double = 0.0,
+    @field:Schema(
+        description = "Length of each audio segment in seconds. Only relevant in ENCODE_SEPARATELY_SEGMENTED mode.",
+        example = "256.0",
+        nullable = false,
+        readOnly = true,
+    )
+    val audioSegmentLength: Double = 0.0,
+    @field:Schema(
+        description = "Number of audio segments",
+        nullable = false,
+        readOnly = true,
+    )
+    val numAudioSegments: Int,
 )
 
 @Validated
@@ -137,12 +157,20 @@ data class EncoreJob(
     val segmentLength: Double? = null,
 
     @field:Schema(
-        description = "If true, and segmented encoding i used, audio will be encoded in segments. Otherwise a separate task will be used to encode the full audio.",
-        example = "true",
-        defaultValue = "true",
+        description = "Defines how audio should be encoded when using segmented encoding. ENCODE_WITH_VIDEO: audio and video together in segments; ENCODE_SEPARATELY_FULL: audio separately as full file; ENCODE_SEPARATELY_SEGMENTED: audio separately in segments.",
+        example = "ENCODE_WITH_VIDEO",
+        defaultValue = "ENCODE_WITH_VIDEO",
         nullable = true,
     )
-    val segmentedEncodingEnabledForAudio: Boolean? = null,
+    val audioEncodingMode: AudioEncodingMode? = null,
+
+    @field:Schema(
+        description = "Length of audio segments in seconds when using ENCODE_SEPARATELY_SEGMENTED mode. If not specified, a value close to 256s will be calculated that is a multiple of the audio frame size.",
+        example = "256.0",
+        nullable = true,
+    )
+    @field:Positive
+    val audioSegmentLength: Double? = null,
 
     @field:Schema(
         description = "Properties for segmented encoding, or null if not used",

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/AudioEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/AudioEncode.kt
@@ -17,7 +17,7 @@ import se.svt.oss.encore.model.output.AudioStreamEncode
 import se.svt.oss.encore.model.output.Output
 
 data class AudioEncode(
-    val codec: String = "libfdk_aac",
+    override val codec: String = "libfdk_aac",
     val bitrate: String? = null,
     val samplerate: Int = 48000,
     val channelLayout: ChannelLayout = ChannelLayout.CH_LAYOUT_STEREO,

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/AudioEncoder.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/AudioEncoder.kt
@@ -12,7 +12,7 @@ private val log = KotlinLogging.logger { }
 abstract class AudioEncoder : OutputProducer {
 
     abstract val optional: Boolean
-    abstract val enabled: Boolean
+    abstract override val enabled: Boolean
 
     fun logOrThrow(message: String): Output? {
         if (optional || !enabled) {

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/AudioEncoder.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/AudioEncoder.kt
@@ -12,6 +12,7 @@ private val log = KotlinLogging.logger { }
 abstract class AudioEncoder : OutputProducer {
 
     abstract val optional: Boolean
+    abstract val codec: String
     abstract override val enabled: Boolean
 
     fun logOrThrow(message: String): Output? {

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/OutputProducer.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/OutputProducer.kt
@@ -21,5 +21,6 @@ import se.svt.oss.encore.model.output.Output
     JsonSubTypes.Type(value = ThumbnailMapEncode::class, name = "ThumbnailMapEncode"),
 )
 interface OutputProducer {
+    val enabled: Boolean
     fun getOutput(job: EncoreJob, encodingProperties: EncodingProperties, filterSettings: FilterSettings): Output?
 }

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/SimpleAudioEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/SimpleAudioEncode.kt
@@ -13,7 +13,7 @@ import se.svt.oss.encore.model.output.AudioStreamEncode
 import se.svt.oss.encore.model.output.Output
 
 data class SimpleAudioEncode(
-    val codec: String = "libfdk_aac",
+    override val codec: String = "libfdk_aac",
     val bitrate: String? = null,
     val samplerate: Int? = null,
     val suffix: String = "_$codec",

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/ThumbnailEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/ThumbnailEncode.kt
@@ -25,7 +25,7 @@ data class ThumbnailEncode(
     val suffixZeroPad: Int = 2,
     val inputLabel: String = DEFAULT_VIDEO_LABEL,
     val optional: Boolean = false,
-    val enabled: Boolean = true,
+    override val enabled: Boolean = true,
     val intervalSeconds: Double? = null,
     val decodeOutput: Int? = null,
 ) : OutputProducer {

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/ThumbnailMapEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/ThumbnailMapEncode.kt
@@ -26,7 +26,7 @@ data class ThumbnailMapEncode(
     val rows: Int = 20,
     val quality: Int = 5,
     val optional: Boolean = true,
-    val enabled: Boolean = true,
+    override val enabled: Boolean = true,
     val suffix: String = "_${cols}x${rows}_${tileWidth}x${tileHeight}_thumbnail_map",
     val format: String = "jpg",
     val inputLabel: String = DEFAULT_VIDEO_LABEL,

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/VideoEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/VideoEncode.kt
@@ -34,7 +34,7 @@ interface VideoEncode : OutputProducer {
     val codec: String
     val inputLabel: String
     val optional: Boolean
-    val enabled: Boolean
+    override val enabled: Boolean
     val cropTo: FractionString?
     val padTo: FractionString?
 

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/queue/QueueItem.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/queue/QueueItem.kt
@@ -21,6 +21,7 @@ enum class TaskType {
     AUDIOVIDEOSEGMENT,
     VIDEOSEGMENT,
     AUDIOFULL,
+    AUDIOSEGMENT,
 }
 
 data class Task(

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/process/SegmentUtil.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/process/SegmentUtil.kt
@@ -5,31 +5,21 @@
 package se.svt.oss.encore.process
 
 import se.svt.oss.encore.model.EncoreJob
-import se.svt.oss.mediaanalyzer.file.MediaContainer
-import kotlin.math.ceil
 
-fun EncoreJob.segmentLengthOrThrow() = segmentLength ?: throw RuntimeException("No segmentLength in job!")
+fun EncoreJob.segmentLengthOrThrow() = segmentedEncodingInfoOrThrow().segmentLength
 
 fun EncoreJob.segmentedEncodingInfoOrThrow() = segmentedEncodingInfo ?: throw RuntimeException("No segmentedEncodingInfo in job!")
 
-fun EncoreJob.numVideoSegments(): Int {
-    val segLen = segmentLengthOrThrow()
-    val readDuration = duration
-    return if (readDuration != null) {
-        ceil(readDuration / segLen).toInt()
-    } else {
-        val segments =
-            inputs.map { ceil(((it.analyzed as MediaContainer).duration - (it.seekTo ?: 0.0)) / segLen).toInt() }.toSet()
-        if (segments.size > 1) {
-            throw RuntimeException("Inputs differ in length")
-        }
-        segments.first()
+fun EncoreJob.segmentDuration(segmentNumber: Int): Double {
+    val numSegments = segmentedEncodingInfoOrThrow().numSegments
+    return when {
+        duration == null -> segmentLengthOrThrow()
+        segmentNumber < numSegments - 1 -> segmentLengthOrThrow()
+        segmentNumber == numSegments - 1 ->
+            // This correctly handles the case where the duration is an exact multiple of the segment length
+            duration!! - segmentLengthOrThrow() * (numSegments - 1)
+        else -> throw IllegalArgumentException("segmentNumber $segmentNumber is out of range for job with $numSegments segments")
     }
-}
-fun EncoreJob.segmentDuration(segmentNumber: Int): Double = when {
-    duration == null -> segmentLengthOrThrow()
-    segmentNumber < numVideoSegments() - 1 -> segmentLengthOrThrow()
-    else -> duration!! % segmentLengthOrThrow()
 }
 
 fun EncoreJob.baseName(segmentNumber: Int) = "${baseName}_%05d".format(segmentNumber)
@@ -39,3 +29,6 @@ fun EncoreJob.segmentSuffixFromFilename(file: String): String {
     val match = regex.find(file) ?: throw RuntimeException("Could not find segment suffix for file $file")
     return match.groupValues[1]
 }
+
+fun EncoreJob.targetFilenameFromSegmentFilename(segmentFile: String) =
+    segmentFile.replace(Regex("^${baseName}_\\d{5}"), baseName)

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/process/SegmentUtil.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/process/SegmentUtil.kt
@@ -33,3 +33,9 @@ fun EncoreJob.segmentDuration(segmentNumber: Int): Double = when {
 }
 
 fun EncoreJob.baseName(segmentNumber: Int) = "${baseName}_%05d".format(segmentNumber)
+
+fun EncoreJob.segmentSuffixFromFilename(file: String): String {
+    val regex = Regex("${baseName}_\\d{5}(.*)")
+    val match = regex.find(file) ?: throw RuntimeException("Could not find segment suffix for file $file")
+    return match.groupValues[1]
+}

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/EncoreService.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/EncoreService.kt
@@ -50,12 +50,11 @@ import se.svt.oss.encore.service.localencode.LocalEncodeService
 import se.svt.oss.encore.service.mediaanalyzer.MediaAnalyzerService
 import se.svt.oss.encore.service.queue.QueueService
 import se.svt.oss.encore.service.remotefiles.RemoteFileService
+import se.svt.oss.encore.service.segmentedencode.SegmentedEncodeService
 import se.svt.oss.mediaanalyzer.file.MediaContainer
 import se.svt.oss.mediaanalyzer.file.MediaFile
 import java.io.File
-import java.nio.file.Paths
 import java.util.Locale
-import kotlin.io.path.isDirectory
 import kotlin.time.TimedValue
 import kotlin.time.measureTimedValue
 
@@ -75,6 +74,7 @@ class EncoreService(
     private val encoreProperties: EncoreProperties,
     private val queueService: QueueService,
     private val remoteFileService: RemoteFileService,
+    private val segmentedEncodeService: SegmentedEncodeService,
 ) {
 
     private val cancelTopicName = "cancel"
@@ -100,17 +100,9 @@ class EncoreService(
         var progressListener: SegmentProgressListener? = null
         try {
             initJob(encoreJob)
+            val tasks = segmentedEncodeService.createTasks(encoreJob)
+            val numTasks = encoreJob.segmentedEncodingInfoOrThrow().numTasks
 
-            val segmentedEncodingInfo = encoreJob.segmentedEncodingInfoOrThrow()
-
-            val separateAudioEncode = !segmentedEncodingInfo.segmentedAudioEncode
-            val numSegments = segmentedEncodingInfo.numSegments
-            val numTasks = segmentedEncodingInfo.numTasks
-
-            log.debug { "Encoding using $numSegments segments" }
-            if (separateAudioEncode) {
-                log.debug { "Encoding audio separately" }
-            }
             redisMessageListerenerContainer.addMessageListener(cancelListener, ChannelTopic.of(cancelTopicName))
             val progressChannel = Channel<Int>()
             progressListener =
@@ -118,35 +110,12 @@ class EncoreService(
             redisMessageListerenerContainer.addMessageListener(progressListener, ChannelTopic.of("segment-progress"))
             val timedOutput = measureTimedValue {
                 sharedWorkDir(encoreJob).mkdirs()
-                var taskNo = 0
-                if (separateAudioEncode) {
+                tasks.forEach {
                     queueService.enqueue(
                         QueueItem(
                             id = encoreJob.id.toString(),
                             priority = encoreJob.priority,
-                            task = Task(
-                                type = TaskType.AUDIOFULL,
-                                taskNo = taskNo++,
-                                segment = 0,
-                            ),
-                        ),
-                    )
-                }
-                val segmentsTaskType = if (separateAudioEncode) {
-                    TaskType.VIDEOSEGMENT
-                } else {
-                    TaskType.AUDIOVIDEOSEGMENT
-                }
-                repeat(numSegments) {
-                    queueService.enqueue(
-                        QueueItem(
-                            id = encoreJob.id.toString(),
-                            priority = encoreJob.priority,
-                            task = Task(
-                                type = segmentsTaskType,
-                                taskNo = taskNo++,
-                                segment = it,
-                            ),
+                            task = it,
                         ),
                     )
                 }
@@ -166,49 +135,7 @@ class EncoreService(
                     throw RuntimeException("Some segments failed")
                 }
                 log.info { "All segments completed" }
-                val outWorkDir = sharedWorkDir(encoreJob)
-                val suffixes = mutableSetOf<String>()
-                repeat(numSegments) { segmentNum ->
-                    val segmentBaseName = encoreJob.baseName(segmentNum)
-                    outWorkDir.list()
-                        ?.filter { !Paths.get(it).isDirectory() }
-                        ?.filter { it.startsWith(segmentBaseName) }
-                        ?.forEach {
-                            val suffix = it.replaceFirst(segmentBaseName, "")
-                            suffixes.add(suffix)
-                            outWorkDir.resolve("$suffix.txt").appendText("file $it\n")
-                        }
-                }
-                val outputFolder = File(encoreJob.outputFolder)
-                outputFolder.mkdirs()
-                val audioFilesMap: MutableMap<String, File> = if (separateAudioEncode) {
-                    sharedWorkDir(encoreJob).resolve("audio")
-                        .listFiles()
-                        ?.filter { it.isFile }
-                        ?.associateBy { it.name }
-                        ?.toMutableMap()
-                        ?: mutableMapOf()
-                } else {
-                    mutableMapOf()
-                }
-                val outputFiles = suffixes.map {
-                    val targetName = encoreJob.baseName + it
-                    log.info { "Joining segments for $targetName" }
-                    val targetFile = outputFolder.resolve(targetName)
-                    val audioFile = audioFilesMap.remove(targetName)
-                    ffmpegExecutor.joinSegments(encoreJob, outWorkDir.resolve("$it.txt"), targetFile, audioFile)
-                }
-                val audioOnlyOutputFiles = if (separateAudioEncode) {
-                    audioFilesMap.values.map {
-                        log.info { "Moving audio file ${it.name} to output folder" }
-                        val target = outputFolder.resolve(it.name)
-                        it.copyTo(target, overwrite = true)
-                        mediaAnalyzerService.analyze(target.absolutePath)
-                    }
-                } else {
-                    emptyList()
-                }
-                outputFiles + audioOnlyOutputFiles
+                segmentedEncodeService.joinSegments(encoreJob, sharedWorkDir(encoreJob))
             }
             updateSuccessfulJob(encoreJob, timedOutput)
         } catch (e: CancellationException) {

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/EncoreService.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/EncoreService.kt
@@ -221,7 +221,14 @@ class EncoreService(
             encoreJob.message = e.message
         } finally {
             repository.save(encoreJob)
-            sharedWorkDirOrNull(encoreJob)?.deleteRecursively()
+            val sharedWorkdDir = sharedWorkDirOrNull(encoreJob)
+            if (sharedWorkdDir != null && sharedWorkdDir.exists()) {
+                if (encoreJob.profileParams["debug.keepSharedWorkDir"]?.toString().toBoolean()) {
+                    log.info { "Keeping shared work dir per profileParams setting: ${sharedWorkDirOrNull(encoreJob)}" }
+                } else {
+                    sharedWorkDirOrNull(encoreJob)?.deleteRecursively()
+                }
+            }
             redisMessageListerenerContainer.removeMessageListener(cancelListener)
             progressListener?.let { redisMessageListerenerContainer.removeMessageListener(it) }
             callbackService.sendProgressCallback(encoreJob)

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/EncoreService.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/EncoreService.kt
@@ -34,13 +34,11 @@ import se.svt.oss.encore.config.EncoreProperties
 import se.svt.oss.encore.model.EncoreJob
 import se.svt.oss.encore.model.RedisEvent
 import se.svt.oss.encore.model.SegmentProgressEvent
-import se.svt.oss.encore.model.SegmentedEncodingInfo
 import se.svt.oss.encore.model.Status
 import se.svt.oss.encore.model.queue.QueueItem
 import se.svt.oss.encore.model.queue.Task
 import se.svt.oss.encore.model.queue.TaskType
 import se.svt.oss.encore.process.baseName
-import se.svt.oss.encore.process.numVideoSegments
 import se.svt.oss.encore.process.segmentDuration
 import se.svt.oss.encore.process.segmentLengthOrThrow
 import se.svt.oss.encore.process.segmentedEncodingInfoOrThrow
@@ -87,9 +85,10 @@ class EncoreService(
             ?: throw IllegalStateException("Shared work dir has not been configured")
 
     fun encode(queueItem: QueueItem, job: EncoreJob) {
+        initJob(job)
         when {
             queueItem.task != null -> encodeSegment(job, queueItem.task)
-            job.segmentLength != null -> encodeSegmented(job)
+            job.segmentedEncodingInfo != null -> encodeSegmented(job)
             else -> encode(job)
         }
     }
@@ -99,9 +98,9 @@ class EncoreService(
         val cancelListener = CancellationListener(objectMapper, encoreJob.id, coroutineJob)
         var progressListener: SegmentProgressListener? = null
         try {
-            initJob(encoreJob)
+            startJob(encoreJob)
             val tasks = segmentedEncodeService.createTasks(encoreJob)
-            val numTasks = encoreJob.segmentedEncodingInfoOrThrow().numTasks
+            val numTasks = tasks.size
 
             redisMessageListerenerContainer.addMessageListener(cancelListener, ChannelTopic.of(cancelTopicName))
             val progressChannel = Channel<Int>()
@@ -148,12 +147,12 @@ class EncoreService(
             encoreJob.message = e.message
         } finally {
             repository.save(encoreJob)
-            val sharedWorkdDir = sharedWorkDirOrNull(encoreJob)
-            if (sharedWorkdDir != null && sharedWorkdDir.exists()) {
+            val sharedWorkDir = sharedWorkDirOrNull(encoreJob)
+            if (sharedWorkDir != null && sharedWorkDir.exists()) {
                 if (encoreJob.profileParams["debug.keepSharedWorkDir"]?.toString().toBoolean()) {
-                    log.info { "Keeping shared work dir per profileParams setting: ${sharedWorkDirOrNull(encoreJob)}" }
+                    log.info { "Keeping shared work dir per profileParams setting: $sharedWorkDir" }
                 } else {
-                    sharedWorkDirOrNull(encoreJob)?.deleteRecursively()
+                    sharedWorkDir.deleteRecursively()
                 }
             }
             redisMessageListerenerContainer.removeMessageListener(cancelListener)
@@ -168,21 +167,56 @@ class EncoreService(
             log.info { "Start encoding ${encoreJob.baseName} task $taskNo/${encoreJob.segmentedEncodingInfo?.numTasks} (${task.type})" }
             val encodingMode = when (task.type) {
                 TaskType.AUDIOFULL -> EncodingMode.AUDIO_ONLY
+                TaskType.AUDIOSEGMENT -> EncodingMode.AUDIO_ONLY
                 TaskType.VIDEOSEGMENT -> EncodingMode.VIDEO_ONLY
                 TaskType.AUDIOVIDEOSEGMENT -> EncodingMode.AUDIO_AND_VIDEO
             }
-            val (job, outputFolder) = if (encodingMode == EncodingMode.AUDIO_ONLY) {
-                Pair(encoreJob, sharedWorkDir(encoreJob).resolve("audio").absolutePath)
-            } else {
-                val segmentNumber = task.segment
-                val job = encoreJob.copy(
-                    baseName = encoreJob.baseName(segmentNumber),
-                    duration = encoreJob.segmentDuration(segmentNumber),
-                    inputs = encoreJob.inputs.map {
-                        it.withSeekTo((it.seekTo ?: 0.0) + encoreJob.segmentLengthOrThrow() * segmentNumber)
-                    },
-                )
-                Pair(job, sharedWorkDir(encoreJob).absolutePath)
+            val (job, outputFolder) = when (task.type) {
+                TaskType.AUDIOFULL -> {
+                    // Full audio, no segmentation
+                    Pair(encoreJob, sharedWorkDir(encoreJob).resolve("audio").absolutePath)
+                }
+                TaskType.AUDIOSEGMENT -> {
+                    // Audio segment with timing and padding
+                    val segmentNumber = task.segment
+                    val segmentedInfo = encoreJob.segmentedEncodingInfoOrThrow()
+                    val numSegments = segmentedInfo.numAudioSegments
+                    val padding = segmentedInfo.audioSegmentPadding
+                    val audioSegmentLength = segmentedInfo.audioSegmentLength
+
+                    // Add padding at start (except first segment) and end (except last segment)
+                    val startPadding = if (segmentNumber == 0) 0.0 else padding
+                    val endPadding = if (segmentNumber == numSegments - 1) 0.0 else padding
+
+                    // Calculate audio segment duration (use remainder for last segment if duration is set)
+                    val baseDuration = when {
+                        encoreJob.duration == null -> audioSegmentLength
+                        segmentNumber < numSegments - 1 -> audioSegmentLength
+                        else -> encoreJob.duration!! - audioSegmentLength * (numSegments - 1)
+                    }
+
+                    val job = encoreJob.copy(
+                        baseName = encoreJob.baseName(segmentNumber),
+                        duration = baseDuration + startPadding + endPadding,
+                        inputs = encoreJob.inputs.map {
+                            val baseSeekTo = (it.seekTo ?: 0.0) + audioSegmentLength * segmentNumber
+                            it.withSeekTo(baseSeekTo - startPadding)
+                        },
+                    )
+                    Pair(job, sharedWorkDir(encoreJob).resolve("audio").absolutePath)
+                }
+                TaskType.VIDEOSEGMENT, TaskType.AUDIOVIDEOSEGMENT -> {
+                    // Video or audio+video segment with timing
+                    val segmentNumber = task.segment
+                    val job = encoreJob.copy(
+                        baseName = encoreJob.baseName(segmentNumber),
+                        duration = encoreJob.segmentDuration(segmentNumber),
+                        inputs = encoreJob.inputs.map {
+                            it.withSeekTo((it.seekTo ?: 0.0) + encoreJob.segmentLengthOrThrow() * segmentNumber)
+                        },
+                    )
+                    Pair(job, sharedWorkDir(encoreJob).absolutePath)
+                }
             }
             ffmpegExecutor.run(job, outputFolder, null, encodingMode)
             redisTemplate.convertAndSend("segment-progress", SegmentProgressEvent(encoreJob.id, taskNo, true))
@@ -205,7 +239,7 @@ class EncoreService(
             outputFolder = localEncodeService.outputFolder(encoreJob)
 
             val timedOutput = measureTimedValue {
-                initJob(encoreJob)
+                startJob(encoreJob)
 
                 val outputFiles = runBlocking(coroutineJob + MDCContext()) {
                     val progressChannel = Channel<Int>()
@@ -285,18 +319,11 @@ class EncoreService(
         encoreJob.inputs.forEach { input ->
             mediaAnalyzerService.analyzeInput(input)
         }
-        if (encoreJob.segmentLength != null) {
-            val segmentedAudioEncode: Boolean = encoreJob.segmentedEncodingEnabledForAudio
-                ?: encoreProperties.encoding.segmentedEncoding.enabledForAudio
-            val numSegments = encoreJob.numVideoSegments()
-            val numTasks = numSegments + if (segmentedAudioEncode) 0 else 1
-            encoreJob.segmentedEncodingInfo = SegmentedEncodingInfo(
-                segmentLength = encoreJob.segmentLengthOrThrow(),
-                segmentedAudioEncode = segmentedAudioEncode,
-                numTasks = numTasks,
-                numSegments = numSegments,
-            )
-        }
+
+        encoreJob.segmentedEncodingInfo = segmentedEncodeService.segmentedEncodingInfo(encoreJob)
+    }
+
+    private fun startJob(encoreJob: EncoreJob) {
         log.info { "Start encoding" }
         encoreJob.status = Status.IN_PROGRESS
         repository.save(encoreJob)

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/FfmpegExecutor.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/FfmpegExecutor.kt
@@ -209,11 +209,29 @@ class FfmpegExecutor(
     private fun totalProgress(subtaskProgress: Int, subtaskIndex: Int, subtaskCount: Int) =
         (subtaskIndex * 100 + subtaskProgress) / subtaskCount
 
-    fun joinSegments(encoreJob: EncoreJob, segmentList: File, targetFile: File, audioFile: File?): MediaFile {
+    fun joinSegments(
+        encoreJob: EncoreJob,
+        segmentList: File,
+        targetFile: File,
+        audioFile: File?,
+        audioSegmentList: File?,
+    ): MediaFile {
+        require(audioFile == null || audioSegmentList == null) {
+            "Cannot provide both audioFile and audioSegmentList"
+        }
+
         val joinParams = profileService.getProfile(encoreJob).joinSegmentParams.toParams()
-        val inputArgs = mutableListOf("-i", "$segmentList")
+        val inputArgs = mutableListOf<String>()
         val mapArgs = mutableListOf("-map", "0")
-        if (audioFile != null) {
+
+        // Add video segments input with concat demuxer
+        inputArgs.addAll(listOf("-f", "concat", "-safe", "0", "-i", "$segmentList"))
+
+        // Add audio input (either segment list with concat or direct file)
+        if (audioSegmentList != null) {
+            inputArgs.addAll(listOf("-f", "concat", "-safe", "0", "-i", "$audioSegmentList"))
+            mapArgs.addAll(listOf("-map", "1"))
+        } else if (audioFile != null) {
             inputArgs.addAll(listOf("-i", audioFile.absolutePath))
             mapArgs.addAll(listOf("-map", "1"))
         }
@@ -224,10 +242,6 @@ class FfmpegExecutor(
             "-loglevel",
             "+level",
             "-y",
-            "-f",
-            "concat",
-            "-safe",
-            "0",
             *inputArgs.toTypedArray(),
             *mapArgs.toTypedArray(),
             "-ignore_unknown",

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/segmentedencode/SegmentedEncodeService.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/segmentedencode/SegmentedEncodeService.kt
@@ -2,65 +2,244 @@ package se.svt.oss.encore.service.segmentedencode
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
+import se.svt.oss.encore.config.EncoreProperties
+import se.svt.oss.encore.model.AudioEncodingMode
 import se.svt.oss.encore.model.EncoreJob
+import se.svt.oss.encore.model.SegmentedEncodingInfo
+import se.svt.oss.encore.model.profile.AudioEncode
+import se.svt.oss.encore.model.profile.AudioEncoder
+import se.svt.oss.encore.model.profile.OutputProducer
+import se.svt.oss.encore.model.profile.Profile
+import se.svt.oss.encore.model.profile.SimpleAudioEncode
+import se.svt.oss.encore.model.profile.VideoEncode
 import se.svt.oss.encore.model.queue.Task
 import se.svt.oss.encore.model.queue.TaskType
-import se.svt.oss.encore.process.baseName
-import se.svt.oss.encore.process.segmentSuffixFromFilename
 import se.svt.oss.encore.process.segmentedEncodingInfoOrThrow
+import se.svt.oss.encore.process.targetFilenameFromSegmentFilename
 import se.svt.oss.encore.service.FfmpegExecutor
 import se.svt.oss.encore.service.mediaanalyzer.MediaAnalyzerService
+import se.svt.oss.encore.service.profile.ProfileService
+import se.svt.oss.encore.util.allAudioEncodes
+import se.svt.oss.encore.util.hasAudioEncodes
+import se.svt.oss.encore.util.hasVideoEncodes
+import se.svt.oss.mediaanalyzer.file.MediaContainer
 import se.svt.oss.mediaanalyzer.file.MediaFile
 import java.io.File
+import kotlin.math.ceil
 
 private val log = KotlinLogging.logger {}
+
+fun OutputProducer?.audioSamplerates(): List<Int> = when {
+    this == null -> emptyList()
+    !this.enabled -> emptyList()
+    this is AudioEncode -> listOf(this.samplerate)
+    this is SimpleAudioEncode -> this.samplerate?.let { listOf(it) } ?: emptyList()
+    this is VideoEncode -> this.audioEncodes.flatMap { it.audioSamplerates() } + this.audioEncode.audioSamplerates()
+    else -> emptyList()
+}
+
+data class AudioEncodingConfig(
+    val audioEncodingMode: AudioEncodingMode,
+    val audioSegmentPadding: Double,
+    val audioSegmentLength: Double,
+    val numSegments: Int,
+)
 
 @Service
 class SegmentedEncodeService(
     private val ffmpegExecutor: FfmpegExecutor,
     private val mediaAnalyzerService: MediaAnalyzerService,
+    private val profileService: ProfileService,
+    private val encoreProperties: EncoreProperties,
 ) {
 
+    fun segmentedEncodingInfo(encoreJob: EncoreJob): SegmentedEncodingInfo? {
+        val profile = profileService.getProfile(encoreJob)
+        val hasVideo = profile.hasVideoEncodes()
+        if (encoreJob.segmentLength == null && hasVideo) {
+            return null
+        }
+        if (encoreJob.segmentLength == null &&
+            encoreJob.audioEncodingMode != AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED
+        ) {
+            return null
+        }
+        val segmentLength = encoreJob.segmentLength ?: 0.0
+        val audioEncodingConfig = audioEncodingConfig(encoreJob, profile)
+        val numVideoSegments = if (hasVideo) numSegments(encoreJob, segmentLength) else 0
+        val numTasks = numVideoSegments + audioEncodingConfig.numSegments
+        return SegmentedEncodingInfo(
+            segmentLength = segmentLength,
+            audioEncodingMode = audioEncodingConfig.audioEncodingMode,
+            numTasks = numTasks,
+            numSegments = numVideoSegments,
+            numAudioSegments = audioEncodingConfig.numSegments,
+            audioSegmentPadding = audioEncodingConfig.audioSegmentPadding,
+            audioSegmentLength = audioEncodingConfig.audioSegmentLength,
+        )
+    }
+
+    fun audioEncodingConfig(encoreJob: EncoreJob, profile: Profile): AudioEncodingConfig {
+        if (!profile.hasAudioEncodes()) {
+            log.info { "No audio encodes found in profile ${profile.name}, skipping audio segmented encoding configuration." }
+            return AudioEncodingConfig(AudioEncodingMode.ENCODE_WITH_VIDEO, 0.0, 0.0, 0)
+        }
+
+        val audioSampleRates = profile.encodes
+            .filter { it.enabled }
+            .flatMap { it.audioSamplerates() }.distinct()
+
+        val audioEncodingMode = audioEncodingMode(encoreJob, profile, audioSampleRates)
+
+        if (audioEncodingMode != AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED) {
+            val numAudioSegments =
+                if (audioEncodingMode == AudioEncodingMode.ENCODE_SEPARATELY_FULL) {
+                    1
+                } else {
+                    0
+                }
+            return AudioEncodingConfig(audioEncodingMode, 0.0, 0.0, numAudioSegments)
+        }
+
+        // Each audio segment is padded with two audio frames at start and end
+        // This padding is then removed when joining segments
+        // This avoids priming samples causing artifacts at segment boundaries
+        // Calculate audio segment padding: 2 * (frame_size / sample_rate)
+        val audioFrameSize = 1024.0 // Standard AAC frame size in samples
+        val maxSampleRate = audioSampleRates.maxOrNull() ?: 48000
+        val audioSegmentPadding = 2.0 * audioFrameSize / maxSampleRate
+
+        // Calculate audio segment length for ENCODE_SEPARATELY_SEGMENTED mode
+        val audioSegmentLength =
+            encoreJob.audioSegmentLength ?: run {
+                // Calculate a value close to 256s that is a multiple of the audio frame size
+                // 256 is selected because it is an integer number of audio frames for both
+                // 44.1kHz and 48kHz sample rates.
+                val frameDuration = audioFrameSize / maxSampleRate
+                val targetDuration = 256.0
+                val numFrames = kotlin.math.round(targetDuration / frameDuration).toLong()
+                numFrames * frameDuration
+            }
+
+        return AudioEncodingConfig(
+            audioEncodingMode,
+            audioSegmentPadding,
+            audioSegmentLength,
+            numSegments(encoreJob, audioSegmentLength),
+        )
+    }
+
+    fun audioEncodingMode(encoreJob: EncoreJob, profile: Profile, audioSampleRates: List<Int>): AudioEncodingMode {
+        // Get the requested audio encoding mode from job or fall back to default
+        val requestedMode = encoreJob.audioEncodingMode
+            ?: encoreProperties.encoding.segmentedEncoding.audioEncodingMode
+
+        val hasNonAacAudioEncode = profile.allAudioEncodes()
+            .filterNot { it.isAacEncoder() }
+            .isNotEmpty()
+
+        return when {
+            requestedMode == AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED && audioSampleRates.size > 1 -> {
+                log.warn { "Multiple audio sample rates detected (${audioSampleRates.joinToString()}), downgrading from ENCODE_SEPARATELY_SEGMENTED to ENCODE_SEPARATELY_FULL" }
+                AudioEncodingMode.ENCODE_SEPARATELY_FULL
+            }
+            requestedMode == AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED && hasNonAacAudioEncode -> {
+                log.warn { "Non-AAC audio encode detected, downgrading from ENCODE_SEPARATELY_SEGMENTED to ENCODE_SEPARATELY_FULL" }
+                AudioEncodingMode.ENCODE_SEPARATELY_FULL
+            }
+            else -> requestedMode
+        }
+    }
+
+    private fun AudioEncoder.isAacEncoder(): Boolean = this.codec == "aac" || this.codec == "libfdk_aac"
+
+    private fun numSegments(encoreJob: EncoreJob, segmentLength: Double): Int {
+        val readDuration = encoreJob.duration
+        return if (readDuration != null) {
+            ceil(readDuration / segmentLength).toInt()
+        } else {
+            val segments =
+                encoreJob.inputs.map { ceil(((it.analyzed as MediaContainer).duration - (it.seekTo ?: 0.0)) / segmentLength).toInt() }
+                    .toSet()
+            if (segments.size > 1) {
+                throw RuntimeException("Inputs differ in length")
+            }
+            segments.first()
+        }
+    }
+
     /**
-     * Create tasks for segmented encoding. One task will be created per segment. If audio is encoded separately,
-     * an additional task for full audio encoding will be created.
+     * Create tasks for segmented encoding based on the audio encoding mode.
+     * - ENCODE_WITH_VIDEO: N tasks of type AUDIOVIDEOSEGMENT
+     * - ENCODE_SEPARATELY_FULL: 1 AUDIOFULL task + N VIDEOSEGMENT tasks
+     * - ENCODE_SEPARATELY_SEGMENTED: M AUDIOSEGMENT tasks + N VIDEOSEGMENT tasks
      */
     fun createTasks(encoreJob: EncoreJob): List<Task> {
         val segmentedEncodingInfo = encoreJob.segmentedEncodingInfoOrThrow()
-
-        val separateAudioEncode = !segmentedEncodingInfo.segmentedAudioEncode
+        val audioEncodingMode = segmentedEncodingInfo.audioEncodingMode
         val numSegments = segmentedEncodingInfo.numSegments
 
-        log.debug { "Encoding using $numSegments segments" }
-        if (separateAudioEncode) {
-            log.debug { "Encoding audio separately" }
-        }
+        log.debug { "Encoding using $numSegments video segments, ${segmentedEncodingInfo.numAudioSegments} audio segments,`0 with audio mode: $audioEncodingMode" }
 
         val tasks = mutableListOf<Task>()
-
         var taskNo = 0
-        if (separateAudioEncode) {
-            tasks.add(
-                Task(
-                    type = TaskType.AUDIOFULL,
-                    taskNo = taskNo++,
-                    segment = 0,
-                ),
-            )
-        }
-        val segmentsTaskType = if (separateAudioEncode) {
-            TaskType.VIDEOSEGMENT
-        } else {
-            TaskType.AUDIOVIDEOSEGMENT
-        }
-        repeat(numSegments) {
-            tasks.add(
-                Task(
-                    type = segmentsTaskType,
-                    taskNo = taskNo++,
-                    segment = it,
-                ),
-            )
+
+        when (audioEncodingMode) {
+            AudioEncodingMode.ENCODE_WITH_VIDEO -> {
+                // Audio and video together in each segment
+                repeat(numSegments) { segmentIndex ->
+                    tasks.add(
+                        Task(
+                            type = TaskType.AUDIOVIDEOSEGMENT,
+                            taskNo = taskNo++,
+                            segment = segmentIndex,
+                        ),
+                    )
+                }
+            }
+            AudioEncodingMode.ENCODE_SEPARATELY_FULL -> {
+                // One full audio task
+                tasks.add(
+                    Task(
+                        type = TaskType.AUDIOFULL,
+                        taskNo = taskNo++,
+                        segment = 0,
+                    ),
+                )
+                // N video segment tasks
+                repeat(numSegments) { segmentIndex ->
+                    tasks.add(
+                        Task(
+                            type = TaskType.VIDEOSEGMENT,
+                            taskNo = taskNo++,
+                            segment = segmentIndex,
+                        ),
+                    )
+                }
+            }
+            AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED -> {
+                val numAudioSegments = segmentedEncodingInfo.numAudioSegments
+                // N audio segment tasks
+                repeat(numAudioSegments) { segmentIndex ->
+                    tasks.add(
+                        Task(
+                            type = TaskType.AUDIOSEGMENT,
+                            taskNo = taskNo++,
+                            segment = segmentIndex,
+                        ),
+                    )
+                }
+                // N video segment tasks
+                repeat(numSegments) { segmentIndex ->
+                    tasks.add(
+                        Task(
+                            type = TaskType.VIDEOSEGMENT,
+                            taskNo = taskNo++,
+                            segment = segmentIndex,
+                        ),
+                    )
+                }
+            }
         }
         return tasks
     }
@@ -69,51 +248,79 @@ class SegmentedEncodeService(
         val target: File,
         val segmentFiles: List<File>,
         val audioFile: File? = null,
+        val audioSegmentFiles: List<File>? = null,
     )
 
     fun prepareJoinSegment(encoreJob: EncoreJob, sharedWorkDir: File): Map<String, JoinSegmentOperation> {
         val segmentedEncodingInfo = encoreJob.segmentedEncodingInfoOrThrow()
-        val separateAudioEncode = !segmentedEncodingInfo.segmentedAudioEncode
+        val audioEncodingMode = segmentedEncodingInfo.audioEncodingMode
 
-        // Groups segment files by suffix/target file
-        val segmentFileMap = sharedWorkDir.listFiles()
+        // Groups video segment files by suffix/target file
+        val videoSegmentFileMap = sharedWorkDir.listFiles()
             .filter { it.isFile }
-            .map { it.name }
             .sorted()
-            .groupBy { encoreJob.segmentSuffixFromFilename(it) }
+            .groupBy { encoreJob.targetFilenameFromSegmentFilename(it.name) }
+
+        val audioFilesMap = if (audioEncodingMode == AudioEncodingMode.ENCODE_SEPARATELY_FULL) {
+            // Full audio files are in the audio subfolder
+            sharedWorkDir.resolve("audio").listFiles().filter { it.isFile }.associateBy { it.name }
+        } else {
+            emptyMap()
+        }
+
+        val audioSegmentFileMap = if (audioEncodingMode == AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED) {
+            // Audio segments are in the audio subfolder
+            val audioDir = sharedWorkDir.resolve("audio")
+            audioDir.listFiles()
+                .filter { it.isFile }
+                .sorted()
+                .groupBy { encoreJob.targetFilenameFromSegmentFilename(it.name) }
+        } else {
+            emptyMap()
+        }
 
         val outputFolder = File(encoreJob.outputFolder)
         outputFolder.mkdirs()
         val joinSegmentOperations = LinkedHashMap<String, JoinSegmentOperation>()
-        segmentFileMap.forEach { (suffix, files) ->
-            val targetName = encoreJob.baseName + suffix
+
+        // Handle video segments and determine corresponding audio
+        videoSegmentFileMap.forEach { (targetName, files) ->
             val targetFile = outputFolder.resolve(targetName)
-            val audioFile = if (separateAudioEncode) {
-                sharedWorkDir.resolve("audio").resolve(targetName).takeIf { it.exists() }
-            } else {
-                null
-            }
+            val audioFile = audioFilesMap[targetName]
+            val audioSegmentFiles = audioSegmentFileMap[targetName]
+
             joinSegmentOperations[targetFile.name] = JoinSegmentOperation(
                 target = targetFile,
                 segmentFiles = files.map { sharedWorkDir.resolve(it) },
                 audioFile = audioFile,
+                audioSegmentFiles = audioSegmentFiles,
             )
         }
 
-        if (separateAudioEncode) {
-            val encodedAudioFiles = sharedWorkDir.resolve("audio")
-                .listFiles()?.asList() ?: emptyList<File>()
-
-            encodedAudioFiles.filter { it.isFile }
-                .filter { !joinSegmentOperations.containsKey(it.name) }
-                .forEach { file ->
-                    joinSegmentOperations[file.name] = JoinSegmentOperation(
-                        target = outputFolder.resolve(file.name),
-                        segmentFiles = emptyList(),
-                        audioFile = file,
-                    )
-                }
+        // Handle audio-only outputs
+        audioFilesMap.forEach { (targetName, audioFile) ->
+            if (!joinSegmentOperations.containsKey(targetName)) {
+                val targetFile = outputFolder.resolve(targetName)
+                joinSegmentOperations[targetName] = JoinSegmentOperation(
+                    target = targetFile,
+                    segmentFiles = emptyList(),
+                    audioFile = audioFile,
+                    audioSegmentFiles = null,
+                )
+            }
         }
+        audioSegmentFileMap.forEach { (targetName, audioSegmentFiles) ->
+            if (!joinSegmentOperations.containsKey(targetName)) {
+                val targetFile = outputFolder.resolve(targetName)
+                joinSegmentOperations[targetName] = JoinSegmentOperation(
+                    target = targetFile,
+                    segmentFiles = emptyList(),
+                    audioFile = null,
+                    audioSegmentFiles = audioSegmentFiles,
+                )
+            }
+        }
+
         return joinSegmentOperations
     }
 
@@ -127,6 +334,39 @@ class SegmentedEncodeService(
 
     fun joinSegments(encoreJob: EncoreJob, sharedWorkDir: File, joinSegmentOperation: JoinSegmentOperation): MediaFile {
         log.info { "Joining segments for ${joinSegmentOperation.target.name}" }
+
+        // Create audio segment list file if audio segments are present
+        val audioSegmentListFile = if (joinSegmentOperation.audioSegmentFiles != null) {
+            log.info { "Preparing to join ${joinSegmentOperation.audioSegmentFiles.size} audio segments with video" }
+            val audioSegmentListFile = sharedWorkDir.resolve("audio/${joinSegmentOperation.target.nameWithoutExtension}_audio_filelist.txt")
+            val segmentedInfo = encoreJob.segmentedEncodingInfoOrThrow()
+            val padding = segmentedInfo.audioSegmentPadding
+            val audioSegmentLength = segmentedInfo.audioSegmentLength
+            val numSegments = joinSegmentOperation.audioSegmentFiles.size
+
+            joinSegmentOperation.audioSegmentFiles.forEachIndexed { index, file ->
+                audioSegmentListFile.appendText("file ${file.absolutePath}\n")
+
+                // Add inpoint/outpoint to trim padding
+                val isFirst = index == 0
+                val isLast = index == numSegments - 1
+                // Trim start padding for all segments except first
+                val inPoint = if (isFirst) 0.0 else padding
+
+                audioSegmentListFile.appendText("inpoint $inPoint\n")
+
+                if (!isLast) {
+                    // Trim end padding for all segments except last
+                    val outpoint = if (isFirst) audioSegmentLength else audioSegmentLength + padding
+                    audioSegmentListFile.appendText("outpoint $outpoint\n")
+                }
+            }
+            audioSegmentListFile
+        } else {
+            null
+        }
+
+        // Join video segments with audio (or just copy audio if no video)
         return if (joinSegmentOperation.segmentFiles.isNotEmpty()) {
             val segmentListFile = sharedWorkDir.resolve("${joinSegmentOperation.target.nameWithoutExtension}_filelist.txt")
             joinSegmentOperation.segmentFiles.forEach { file ->
@@ -137,12 +377,19 @@ class SegmentedEncodeService(
                 segmentListFile,
                 joinSegmentOperation.target,
                 joinSegmentOperation.audioFile,
+                audioSegmentListFile,
             )
         } else {
-            log.info { "Moving audio file ${joinSegmentOperation.audioFile} to output folder" }
-            val target = joinSegmentOperation.target
-            joinSegmentOperation.audioFile!!.copyTo(target, overwrite = true)
-            mediaAnalyzerService.analyze(target.absolutePath)
+            // Audio-only output: either segments or full file
+            if (audioSegmentListFile != null) {
+                log.info { "Joining audio-only segments for ${joinSegmentOperation.target.name}" }
+                ffmpegExecutor.joinSegments(encoreJob, audioSegmentListFile, joinSegmentOperation.target, null, null)
+            } else {
+                log.info { "Moving audio file ${joinSegmentOperation.audioFile} to output folder" }
+                val target = joinSegmentOperation.target
+                joinSegmentOperation.audioFile!!.copyTo(target, overwrite = true)
+                mediaAnalyzerService.analyze(target.absolutePath)
+            }
         }
     }
 }

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/segmentedencode/SegmentedEncodeService.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/segmentedencode/SegmentedEncodeService.kt
@@ -1,0 +1,148 @@
+package se.svt.oss.encore.service.segmentedencode
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+import se.svt.oss.encore.model.EncoreJob
+import se.svt.oss.encore.model.queue.Task
+import se.svt.oss.encore.model.queue.TaskType
+import se.svt.oss.encore.process.baseName
+import se.svt.oss.encore.process.segmentSuffixFromFilename
+import se.svt.oss.encore.process.segmentedEncodingInfoOrThrow
+import se.svt.oss.encore.service.FfmpegExecutor
+import se.svt.oss.encore.service.mediaanalyzer.MediaAnalyzerService
+import se.svt.oss.mediaanalyzer.file.MediaFile
+import java.io.File
+
+private val log = KotlinLogging.logger {}
+
+@Service
+class SegmentedEncodeService(
+    private val ffmpegExecutor: FfmpegExecutor,
+    private val mediaAnalyzerService: MediaAnalyzerService,
+) {
+
+    /**
+     * Create tasks for segmented encoding. One task will be created per segment. If audio is encoded separately,
+     * an additional task for full audio encoding will be created.
+     */
+    fun createTasks(encoreJob: EncoreJob): List<Task> {
+        val segmentedEncodingInfo = encoreJob.segmentedEncodingInfoOrThrow()
+
+        val separateAudioEncode = !segmentedEncodingInfo.segmentedAudioEncode
+        val numSegments = segmentedEncodingInfo.numSegments
+
+        log.debug { "Encoding using $numSegments segments" }
+        if (separateAudioEncode) {
+            log.debug { "Encoding audio separately" }
+        }
+
+        val tasks = mutableListOf<Task>()
+
+        var taskNo = 0
+        if (separateAudioEncode) {
+            tasks.add(
+                Task(
+                    type = TaskType.AUDIOFULL,
+                    taskNo = taskNo++,
+                    segment = 0,
+                ),
+            )
+        }
+        val segmentsTaskType = if (separateAudioEncode) {
+            TaskType.VIDEOSEGMENT
+        } else {
+            TaskType.AUDIOVIDEOSEGMENT
+        }
+        repeat(numSegments) {
+            tasks.add(
+                Task(
+                    type = segmentsTaskType,
+                    taskNo = taskNo++,
+                    segment = it,
+                ),
+            )
+        }
+        return tasks
+    }
+
+    data class JoinSegmentOperation(
+        val target: File,
+        val segmentFiles: List<File>,
+        val audioFile: File? = null,
+    )
+
+    fun prepareJoinSegment(encoreJob: EncoreJob, sharedWorkDir: File): Map<String, JoinSegmentOperation> {
+        val segmentedEncodingInfo = encoreJob.segmentedEncodingInfoOrThrow()
+        val separateAudioEncode = !segmentedEncodingInfo.segmentedAudioEncode
+
+        // Groups segment files by suffix/target file
+        val segmentFileMap = sharedWorkDir.listFiles()
+            .filter { it.isFile }
+            .map { it.name }
+            .sorted()
+            .groupBy { encoreJob.segmentSuffixFromFilename(it) }
+
+        val outputFolder = File(encoreJob.outputFolder)
+        outputFolder.mkdirs()
+        val joinSegmentOperations = LinkedHashMap<String, JoinSegmentOperation>()
+        segmentFileMap.forEach { (suffix, files) ->
+            val targetName = encoreJob.baseName + suffix
+            val targetFile = outputFolder.resolve(targetName)
+            val audioFile = if (separateAudioEncode) {
+                sharedWorkDir.resolve("audio").resolve(targetName).takeIf { it.exists() }
+            } else {
+                null
+            }
+            joinSegmentOperations[targetFile.name] = JoinSegmentOperation(
+                target = targetFile,
+                segmentFiles = files.map { sharedWorkDir.resolve(it) },
+                audioFile = audioFile,
+            )
+        }
+
+        if (separateAudioEncode) {
+            val encodedAudioFiles = sharedWorkDir.resolve("audio")
+                .listFiles()?.asList() ?: emptyList<File>()
+
+            encodedAudioFiles.filter { it.isFile }
+                .filter { !joinSegmentOperations.containsKey(it.name) }
+                .forEach { file ->
+                    joinSegmentOperations[file.name] = JoinSegmentOperation(
+                        target = outputFolder.resolve(file.name),
+                        segmentFiles = emptyList(),
+                        audioFile = file,
+                    )
+                }
+        }
+        return joinSegmentOperations
+    }
+
+    fun joinSegments(encoreJob: EncoreJob, sharedWorkDir: File): List<MediaFile> {
+        val joinSegmentOperations = prepareJoinSegment(encoreJob, sharedWorkDir)
+
+        return joinSegmentOperations.values.map { joinSegmentOperation ->
+            joinSegments(encoreJob, sharedWorkDir, joinSegmentOperation)
+        }
+    }
+
+    fun joinSegments(encoreJob: EncoreJob, sharedWorkDir: File, joinSegmentOperation: JoinSegmentOperation): MediaFile {
+        log.info { "Joining segments for ${joinSegmentOperation.target.name}" }
+        return if (joinSegmentOperation.segmentFiles.isNotEmpty()) {
+            val segmentListFile = sharedWorkDir.resolve("${joinSegmentOperation.target.nameWithoutExtension}_filelist.txt")
+            joinSegmentOperation.segmentFiles.forEach { file ->
+                segmentListFile.appendText("file ${file.absolutePath}\n")
+            }
+            ffmpegExecutor.joinSegments(
+                encoreJob,
+                segmentListFile,
+                joinSegmentOperation.target,
+                joinSegmentOperation.audioFile,
+            )
+        } else {
+            log.info { "Moving audio file ${joinSegmentOperation.audioFile} to output folder" }
+            val target = joinSegmentOperation.target
+            joinSegmentOperation.audioFile!!.copyTo(target, overwrite = true)
+            mediaAnalyzerService.analyze(target.absolutePath)
+        }
+    }
+}

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/util/ProfileUtil.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/util/ProfileUtil.kt
@@ -1,0 +1,51 @@
+package se.svt.oss.encore.util
+
+import se.svt.oss.encore.model.profile.AudioEncode
+import se.svt.oss.encore.model.profile.AudioEncoder
+import se.svt.oss.encore.model.profile.Profile
+import se.svt.oss.encore.model.profile.SimpleAudioEncode
+import se.svt.oss.encore.model.profile.VideoEncode
+
+fun Profile.hasAudioEncodes(): Boolean = this.encodes
+    .filter { it.enabled }
+    .any { encode ->
+        when (encode) {
+            is VideoEncode ->
+                encode.audioEncode?.enabled == true || encode.audioEncodes.any { it.enabled }
+            is AudioEncode,
+            is SimpleAudioEncode,
+            -> true
+            else -> false
+        }
+    }
+
+fun Profile.allAudioEncodes(): List<AudioEncoder> =
+    this.encodes
+        .filter { it.enabled }
+        .flatMap { encode ->
+            when (encode) {
+                is VideoEncode -> encode.allAudioEncodes()
+                is AudioEncoder -> listOf(encode)
+                else -> emptyList()
+            }
+        }
+
+fun VideoEncode.allAudioEncodes(): List<AudioEncoder> {
+    val audioEncodes = mutableListOf<AudioEncoder>()
+    this.audioEncode?.let {
+        if (it.enabled) {
+            audioEncodes.add(it)
+        }
+    }
+    audioEncodes.addAll(this.audioEncodes.filter { it.enabled })
+    return audioEncodes
+}
+
+fun Profile.hasVideoEncodes(): Boolean = this.encodes
+    .filter { it.enabled }
+    .any { encode ->
+        when (encode) {
+            is VideoEncode -> true
+            else -> false
+        }
+    }

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/EncoreIntegrationTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/EncoreIntegrationTest.kt
@@ -28,7 +28,7 @@ class EncoreIntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo) : EncoreIn
 
     @Test
     fun jobIsSuccessfulSurround(@TempDir outputDir: File) {
-        successfulTest(
+        val createdJob = successfulTest(
             job(outputDir = outputDir, file = testFileSurround),
             defaultExpectedOutputFiles(outputDir, testFileSurround) +
                 listOf(
@@ -40,11 +40,10 @@ class EncoreIntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo) : EncoreIn
     }
 
     @Test
-    fun jobIsSuccessfulSurroundSegmentedEncodeSeparateAudio(@TempDir outputDir: File) {
+    fun jobIsSuccessfulSurroundSegmentedEncode(@TempDir outputDir: File) {
         val job = job(outputDir = outputDir, file = testFileSurround).copy(
             profile = "separate-video-audio",
             segmentLength = 3.84,
-            segmentedEncodingEnabledForAudio = false,
             priority = 100,
         )
         val expectedFiles = listOf(
@@ -63,9 +62,68 @@ class EncoreIntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo) : EncoreIn
             expectedFiles,
         )
         assertThat(createdJob.segmentedEncodingInfo)
-            .hasSegmentedAudioEncode(false)
+            .hasAudioEncodingMode(se.svt.oss.encore.model.AudioEncodingMode.ENCODE_WITH_VIDEO)
+            .hasNumSegments(3)
+            .hasNumAudioSegments(0)
+            .hasNumTasks(3)
+    }
+
+    @Test
+    fun jobIsSuccessfulSurroundSegmentedEncodeSeparateAudio(@TempDir outputDir: File) {
+        val job = job(outputDir = outputDir, file = testFileSurround).copy(
+            profile = "separate-video-audio",
+            segmentLength = 3.84,
+            audioEncodingMode = se.svt.oss.encore.model.AudioEncodingMode.ENCODE_SEPARATELY_FULL,
+            priority = 100,
+        )
+        val expectedFiles = listOf(
+            "x264_3100.mp4",
+            "STEREO.mp4",
+        )
+            .map { expectedFile(outputDir, testFileSurround, it) } +
+            listOf(
+                expectedFile(outputDir, testFileSurround, "STEREO_DE.mp4"),
+                expectedFile(outputDir, testFileSurround, "SURROUND.mp4"),
+                expectedFile(outputDir, testFileSurround, "SURROUND_DE.mp4"),
+            )
+
+        val createdJob = successfulTest(
+            job,
+            expectedFiles,
+        )
+        assertThat(createdJob.segmentedEncodingInfo)
+            .hasAudioEncodingMode(se.svt.oss.encore.model.AudioEncodingMode.ENCODE_SEPARATELY_FULL)
             .hasNumSegments(3)
             .hasNumTasks(4)
+    }
+
+    @Test
+    fun jobIsSuccessfulSegmentedEncodeSeparatelySegmentedAudio(@TempDir outputDir: File) {
+        val job = job(outputDir = outputDir, file = testFileSurround).copy(
+            profile = "separate-video-audio",
+            segmentLength = 3.84,
+            audioEncodingMode = se.svt.oss.encore.model.AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED,
+            audioSegmentLength = 8.0,
+            priority = 100,
+            profileParams = mapOf("enableSurround" to "false"), // segmented audio encode not supported for surround
+        )
+        val expectedFiles = listOf(
+            "x264_3100.mp4",
+            "STEREO.mp4",
+        )
+            .map { expectedFile(outputDir, testFileSurround, it) } +
+            listOf(
+                expectedFile(outputDir, testFileSurround, "STEREO_DE.mp4"),
+            )
+
+        val createdJob = successfulTest(
+            job,
+            expectedFiles,
+        )
+        assertThat(createdJob.segmentedEncodingInfo)
+            .hasAudioEncodingMode(se.svt.oss.encore.model.AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED)
+            .hasNumSegments(3)
+            .hasNumTasks(5) // 2 audio segments + 3 video segments
     }
 
     @Test
@@ -80,7 +138,7 @@ class EncoreIntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo) : EncoreIn
         val expectedOutPut = listOf(outputDir.resolve("$baseName.mp4").absolutePath)
         val createdJob = successfulTest(job, expectedOutPut)
         assertThat(createdJob.segmentedEncodingInfo)
-            .hasSegmentedAudioEncode(true)
+            .hasAudioEncodingMode(se.svt.oss.encore.model.AudioEncodingMode.ENCODE_WITH_VIDEO)
             .hasNumSegments(3)
             .hasNumTasks(3)
         assertThat(createdJob.output)
@@ -111,7 +169,7 @@ class EncoreIntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo) : EncoreIn
             profile = "audio-streams",
             segmentLength = 3.84,
             priority = 100,
-            segmentedEncodingEnabledForAudio = false,
+            audioEncodingMode = se.svt.oss.encore.model.AudioEncodingMode.ENCODE_SEPARATELY_FULL,
         )
         val expectedOutPut = listOf(outputDir.resolve("$baseName.mp4").absolutePath)
         val createdJob = successfulTest(job, expectedOutPut)
@@ -121,7 +179,7 @@ class EncoreIntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo) : EncoreIn
         assertThat(createdJob.output[0])
             .isInstanceOf(VideoFile::class.java)
         assertThat(createdJob.segmentedEncodingInfo)
-            .hasSegmentedAudioEncode(false)
+            .hasAudioEncodingMode(se.svt.oss.encore.model.AudioEncodingMode.ENCODE_SEPARATELY_FULL)
             .hasNumSegments(3)
             .hasNumTasks(4)
 
@@ -291,5 +349,29 @@ class EncoreIntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo) : EncoreIn
 
         assertThat(createdJob.message)
             .contains("Coding might not be compatible on all devices")
+    }
+
+    @Test
+    fun jobIsSuccessfulAudioOnlySegmentedEncode(@TempDir outputDir: File) {
+        val job = job(outputDir = outputDir, file = testFileSurround).copy(
+            profile = "audio-only",
+            segmentLength = 3.84,
+            audioEncodingMode = se.svt.oss.encore.model.AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED,
+            audioSegmentLength = 235 * 1024 / 48000.0, // 235 audio frames ~= 5.013333s
+            priority = 100,
+        )
+        val expectedFiles = listOf(
+            "STEREO.mp4",
+            "STEREO_DE.mp4",
+        ).map { expectedFile(outputDir, testFileSurround, it) }
+
+        val createdJob = successfulTest(
+            job,
+            expectedFiles,
+        )
+        assertThat(createdJob.segmentedEncodingInfo)
+            .hasAudioEncodingMode(se.svt.oss.encore.model.AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED)
+            .hasNumSegments(0) // No video segments
+            .hasNumTasks(2) // Only 2 audio segments
     }
 }

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/process/SegmentUtilTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/process/SegmentUtilTest.kt
@@ -5,78 +5,134 @@
 package se.svt.oss.encore.process
 
 import org.assertj.core.data.Offset
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import se.svt.oss.encore.Assertions.assertThat
 import se.svt.oss.encore.Assertions.assertThatThrownBy
 import se.svt.oss.encore.defaultEncoreJob
-import se.svt.oss.encore.defaultVideoFile
 import se.svt.oss.encore.longVideoFile
+import se.svt.oss.encore.model.AudioEncodingMode
+import se.svt.oss.encore.model.SegmentedEncodingInfo
 import se.svt.oss.encore.model.input.AudioVideoInput
+import kotlin.math.ceil
 
 class SegmentUtilTest {
 
     private val job = defaultEncoreJob().copy(
         baseName = "segment_test",
-        segmentLength = 19.2,
         duration = null,
         inputs = listOf(AudioVideoInput(uri = "test", analyzed = longVideoFile)),
+        segmentedEncodingInfo = SegmentedEncodingInfo(
+            segmentLength = 19.2,
+            numSegments = ceil(longVideoFile.duration / 19.2).toInt(),
+            numTasks = ceil(longVideoFile.duration / 19.2).toInt(),
+            audioEncodingMode = AudioEncodingMode.ENCODE_WITH_VIDEO,
+            audioSegmentPadding = 0.0,
+            audioSegmentLength = 0.0,
+            numAudioSegments = 0,
+        ),
     )
 
-    @Test
-    fun baseName() {
-        assertThat(job.baseName(2)).isEqualTo("segment_test_00002")
+    @Nested
+    inner class SegmentDurationTest {
+
+        @Test
+        fun `returns full segment length when duration not set`() {
+            assertThat(job.segmentDuration(0)).isEqualTo(19.2)
+            assertThat(job.segmentDuration(5)).isEqualTo(19.2)
+            assertThat(job.segmentDuration(140)).isEqualTo(19.2)
+        }
+
+        @Test
+        fun `returns full segment length for non-last segments when duration set`() {
+            val jobWithDuration = job.copy(
+                duration = 125.0,
+                segmentedEncodingInfo = job.segmentedEncodingInfo!!.copy(
+                    numSegments = 7,
+                ),
+            )
+            assertThat(jobWithDuration.segmentDuration(0)).isEqualTo(19.2)
+            assertThat(jobWithDuration.segmentDuration(3)).isEqualTo(19.2)
+            assertThat(jobWithDuration.segmentDuration(5)).isEqualTo(19.2)
+        }
+
+        @Test
+        fun `returns remainder for last segment when duration set`() {
+            val jobWithDuration = job.copy(
+                duration = 125.0,
+                segmentedEncodingInfo = job.segmentedEncodingInfo!!.copy(
+                    numSegments = 7,
+                ),
+            )
+            // 125.0 % 19.2 = 9.8
+            assertThat(jobWithDuration.segmentDuration(6)).isCloseTo(9.8, Offset.offset(0.001))
+        }
+
+        @Test
+        fun `handles exact multiple of segment length`() {
+            val jobWithDuration = job.copy(
+                duration = 96.0, // Exactly 5 segments of 19.2
+                segmentedEncodingInfo = job.segmentedEncodingInfo!!.copy(
+                    numSegments = 5,
+                ),
+            )
+            // When duration is an exact multiple of segment length,
+            // the last segment should still have the full segment length
+            assertThat(jobWithDuration.segmentDuration(4)).isCloseTo(19.2, Offset.offset(0.001))
+        }
+
+        @Test
+        fun `throws exception for invalid segment number`() {
+            val jobWithDuration = job.copy(
+                duration = 96.0, // Exactly 5 segments of 19.2
+                segmentedEncodingInfo = job.segmentedEncodingInfo!!.copy(
+                    numSegments = 5,
+                ),
+            )
+
+            assertThatThrownBy { jobWithDuration.segmentDuration(5) }
+                .hasMessage("segmentNumber 5 is out of range for job with 5 segments")
+        }
+
+        @Test
+        fun `throws exception when segmentedEncodingInfo is missing`() {
+            val jobWithoutInfo = job.copy(segmentedEncodingInfo = null)
+            assertThatThrownBy {
+                jobWithoutInfo.segmentDuration(0)
+            }.hasMessage("No segmentedEncodingInfo in job!")
+        }
     }
 
-    @Test
-    fun missingSegmentLength() {
-        val encoreJob = job.copy(segmentLength = null)
-        val message = "No segmentLength in job!"
-        assertThatThrownBy {
-            encoreJob.segmentLengthOrThrow()
-        }.hasMessage(message)
-        assertThatThrownBy {
-            encoreJob.numVideoSegments()
-        }.hasMessage(message)
-        assertThatThrownBy {
-            encoreJob.segmentDuration(1)
-        }.hasMessage(message)
+    @Nested
+    inner class BaseNameTest {
+
+        @Test
+        fun `generates correct base name with segment number`() {
+            assertThat(job.baseName(2)).isEqualTo("segment_test_00002")
+        }
     }
 
-    @Test
-    fun hasSegmentLength() {
-        assertThat(job.segmentLengthOrThrow()).isEqualTo(19.2)
-    }
+    @Nested
+    inner class SegmentSuffixFromFilenameTest {
 
-    @Test
-    fun numVideoSegmentsDurationSet() {
-        val encoreJob = job.copy(duration = 125.0)
-        assertThat(encoreJob.numVideoSegments()).isEqualTo(7)
-    }
+        @Test
+        fun `extracts suffix from segment filename`() {
+            val encoreJob = job.copy(baseName = "test_video")
+            assertThat(encoreJob.segmentSuffixFromFilename("test_video_00003_720p.mp4")).isEqualTo("_720p.mp4")
+        }
 
-    @Test
-    fun numVideoSegmentsDurationNotSet() {
-        assertThat(job.numVideoSegments()).isEqualTo(141)
-    }
+        @Test
+        fun `extracts suffix when no additional suffix present`() {
+            val encoreJob = job.copy(baseName = "test_video")
+            assertThat(encoreJob.segmentSuffixFromFilename("test_video_00000.mp4")).isEqualTo(".mp4")
+        }
 
-    @Test
-    fun numVideoSegmentsInputsDiffer() {
-        val encoreJob = job.copy(inputs = job.inputs + AudioVideoInput(uri = "test", analyzed = defaultVideoFile))
-        assertThatThrownBy { encoreJob.numVideoSegments() }
-            .hasMessage("Inputs differ in length")
-    }
-
-    @Test
-    fun segmentDurationDurationNotSet() {
-        assertThat(job.segmentDuration(140)).isEqualTo(19.2)
-    }
-
-    @Test
-    fun segmentDurationDurationSetFirst() {
-        assertThat(job.copy(duration = 125.0).segmentDuration(0)).isEqualTo(19.2)
-    }
-
-    @Test
-    fun segmentDurationDurationSetLast() {
-        assertThat(job.copy(duration = 125.0).segmentDuration(6)).isCloseTo(9.8, Offset.offset(0.001))
+        @Test
+        fun `throws exception for invalid segment filename`() {
+            val encoreJob = job.copy(baseName = "test_video")
+            assertThatThrownBy {
+                encoreJob.segmentSuffixFromFilename("wrong_name.mp4")
+            }.hasMessageContaining("Could not find segment suffix for file wrong_name.mp4")
+        }
     }
 }

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/service/segmentedencode/SegmentedEncodeServiceTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/service/segmentedencode/SegmentedEncodeServiceTest.kt
@@ -1,0 +1,310 @@
+// SPDX-FileCopyrightText: 2025 Eyevinn Technology AB
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.svt.oss.encore.service.segmentedencode
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import se.svt.oss.encore.defaultEncoreJob
+import se.svt.oss.encore.model.SegmentedEncodingInfo
+import se.svt.oss.encore.model.queue.TaskType
+import se.svt.oss.encore.service.FfmpegExecutor
+import se.svt.oss.encore.service.mediaanalyzer.MediaAnalyzerService
+import se.svt.oss.mediaanalyzer.file.MediaFile
+import java.io.File
+
+class SegmentedEncodeServiceTest {
+
+    private val ffmpegExecutor: FfmpegExecutor = mockk()
+    private val mediaAnalyzerService: MediaAnalyzerService = mockk()
+    private val service = SegmentedEncodeService(ffmpegExecutor, mediaAnalyzerService)
+
+    private fun createJobWithSegmentedEncoding(
+        numSegments: Int,
+        segmentedAudioEncode: Boolean,
+        outputFolder: String = "/output/path",
+        baseName: String = "test",
+    ) = defaultEncoreJob().copy(
+        outputFolder = outputFolder,
+        baseName = baseName,
+        segmentedEncodingInfo = SegmentedEncodingInfo(
+            segmentLength = 10.0,
+            numSegments = numSegments,
+            numTasks = if (segmentedAudioEncode) numSegments else numSegments + 1,
+            segmentedAudioEncode = segmentedAudioEncode,
+        ),
+    )
+
+    private fun createSegmentFiles(workDir: File, baseName: String, suffixes: List<String>, segmentCount: Int) {
+        suffixes.forEach { suffix ->
+            repeat(segmentCount) { i ->
+                File(workDir, "${baseName}_${"%05d".format(i)}$suffix").writeText("segment$i")
+            }
+        }
+    }
+
+    private fun setupDirectories(tempDir: File): Pair<File, File> {
+        val outputFolder = File(tempDir, "output").apply { mkdirs() }
+        val workDir = File(tempDir, "work").apply { mkdirs() }
+        return outputFolder to workDir
+    }
+
+    private fun assertOperationMatches(
+        operation: SegmentedEncodeService.JoinSegmentOperation,
+        expectedTarget: File,
+        expectedSegments: List<File>,
+        expectedAudio: File? = null,
+    ) {
+        assertEquals(expectedTarget, operation.target)
+        assertEquals(expectedSegments.size, operation.segmentFiles.size)
+        expectedSegments.forEachIndexed { index, expectedFile ->
+            assertEquals(expectedFile, operation.segmentFiles[index])
+        }
+        if (expectedAudio != null) {
+            assertEquals(expectedAudio, operation.audioFile)
+        } else {
+            assertNull(operation.audioFile)
+        }
+    }
+
+    private fun expectedSegmentFiles(workDir: File, baseName: String, suffix: String, count: Int): List<File> =
+        (0 until count).map { File(workDir, "${baseName}_${"%05d".format(it)}$suffix") }
+
+    private fun createSegmentFilesList(workDir: File, baseName: String, suffix: String, count: Int): List<File> =
+        expectedSegmentFiles(workDir, baseName, suffix, count).onEach { it.writeText("segment") }
+
+    private fun expectedSegmentListContent(segments: List<File>): String =
+        segments.joinToString("\n", postfix = "\n") { "file ${it.absolutePath}" }
+
+    private fun assertSegmentListFileMatches(actual: File, expectedFile: File, expectedSegments: List<File>) {
+        assertEquals(expectedFile, actual)
+        assertEquals(true, actual.exists())
+        assertEquals(expectedSegmentListContent(expectedSegments), actual.readText())
+    }
+
+    @Nested
+    inner class CreateTasksTest {
+
+        @ParameterizedTest(name = "numSegments={0}, segmentedAudio={1} creates {2} tasks")
+        @CsvSource(
+            "3, true, 3",
+            "10, true, 10",
+            "3, false, 4",
+            "1, false, 2",
+        )
+        fun `creates correct number of tasks`(numSegments: Int, segmentedAudioEncode: Boolean, expectedTasks: Int) {
+            val encoreJob = createJobWithSegmentedEncoding(numSegments, segmentedAudioEncode)
+
+            val tasks = service.createTasks(encoreJob)
+
+            assertEquals(expectedTasks, tasks.size)
+        }
+
+        @Test
+        fun `creates audio-video segment tasks when audio is segmented`() {
+            val encoreJob = createJobWithSegmentedEncoding(numSegments = 3, segmentedAudioEncode = true)
+
+            val tasks = service.createTasks(encoreJob)
+
+            tasks.forEachIndexed { index, task ->
+                assertEquals(TaskType.AUDIOVIDEOSEGMENT, task.type)
+                assertEquals(index, task.taskNo)
+                assertEquals(index, task.segment)
+            }
+        }
+
+        @Test
+        fun `creates separate audio task and video segments when audio is not segmented`() {
+            val encoreJob = createJobWithSegmentedEncoding(numSegments = 3, segmentedAudioEncode = false)
+
+            val tasks = service.createTasks(encoreJob)
+
+            assertEquals(TaskType.AUDIOFULL, tasks[0].type)
+            assertEquals(0, tasks[0].taskNo)
+
+            tasks.drop(1).forEachIndexed { index, task ->
+                assertEquals(TaskType.VIDEOSEGMENT, task.type)
+                assertEquals(index + 1, task.taskNo)
+                assertEquals(index, task.segment)
+            }
+        }
+    }
+
+    @Nested
+    inner class PrepareJoinSegmentTest {
+
+        @TempDir
+        lateinit var tempDir: File
+
+        @Test
+        fun `prepares join operations for segmented audio encode`() {
+            val (outputFolder, workDir) = setupDirectories(tempDir)
+            createSegmentFiles(workDir, "test", listOf("_720p.mp4", "_1080p.mp4"), 3)
+
+            val encoreJob = createJobWithSegmentedEncoding(
+                numSegments = 3,
+                segmentedAudioEncode = true,
+                outputFolder = outputFolder.absolutePath,
+            )
+
+            val operations = service.prepareJoinSegment(encoreJob, workDir)
+
+            assertEquals(2, operations.size)
+            assertOperationMatches(
+                operations["test_720p.mp4"]!!,
+                expectedTarget = File(outputFolder, "test_720p.mp4"),
+                expectedSegments = expectedSegmentFiles(workDir, "test", "_720p.mp4", 3),
+            )
+            assertOperationMatches(
+                operations["test_1080p.mp4"]!!,
+                expectedTarget = File(outputFolder, "test_1080p.mp4"),
+                expectedSegments = expectedSegmentFiles(workDir, "test", "_1080p.mp4", 3),
+            )
+        }
+
+        @Test
+        fun `prepares join operations for separate audio encode`() {
+            val (outputFolder, workDir) = setupDirectories(tempDir)
+            val audioDir = File(workDir, "audio").apply { mkdirs() }
+
+            createSegmentFiles(workDir, "test", listOf("_720p.mp4"), 2)
+            File(audioDir, "test_720p.mp4").writeText("audio")
+            File(audioDir, "test_audio.mp4").writeText("audio_only")
+
+            val encoreJob = createJobWithSegmentedEncoding(
+                numSegments = 2,
+                segmentedAudioEncode = false,
+                outputFolder = outputFolder.absolutePath,
+            )
+
+            val operations = service.prepareJoinSegment(encoreJob, workDir)
+
+            assertEquals(2, operations.size)
+            assertOperationMatches(
+                operations["test_720p.mp4"]!!,
+                expectedTarget = File(outputFolder, "test_720p.mp4"),
+                expectedSegments = expectedSegmentFiles(workDir, "test", "_720p.mp4", 2),
+                expectedAudio = File(audioDir, "test_720p.mp4"),
+            )
+            assertOperationMatches(
+                operations["test_audio.mp4"]!!,
+                expectedTarget = File(outputFolder, "test_audio.mp4"),
+                expectedSegments = emptyList(),
+                expectedAudio = File(audioDir, "test_audio.mp4"),
+            )
+        }
+
+        @Test
+        fun `groups segment files by suffix correctly`() {
+            val (outputFolder, workDir) = setupDirectories(tempDir)
+            createSegmentFiles(workDir, "test", listOf(".mp4", "_high.mp4", "_low.mp4"), 2)
+
+            val encoreJob = createJobWithSegmentedEncoding(
+                numSegments = 2,
+                segmentedAudioEncode = true,
+                outputFolder = outputFolder.absolutePath,
+            )
+
+            val operations = service.prepareJoinSegment(encoreJob, workDir)
+
+            assertEquals(3, operations.size)
+            assertOperationMatches(
+                operations["test.mp4"]!!,
+                expectedTarget = File(outputFolder, "test.mp4"),
+                expectedSegments = expectedSegmentFiles(workDir, "test", ".mp4", 2),
+            )
+            assertOperationMatches(
+                operations["test_high.mp4"]!!,
+                expectedTarget = File(outputFolder, "test_high.mp4"),
+                expectedSegments = expectedSegmentFiles(workDir, "test", "_high.mp4", 2),
+            )
+            assertOperationMatches(
+                operations["test_low.mp4"]!!,
+                expectedTarget = File(outputFolder, "test_low.mp4"),
+                expectedSegments = expectedSegmentFiles(workDir, "test", "_low.mp4", 2),
+            )
+        }
+    }
+
+    @Nested
+    inner class JoinSegmentsTest {
+
+        @TempDir
+        lateinit var tempDir: File
+
+        @Test
+        fun `joins segments with audio file`() {
+            val (outputFolder, workDir) = setupDirectories(tempDir)
+            val audioDir = File(workDir, "audio").apply { mkdirs() }
+
+            val segments = createSegmentFilesList(workDir, "test", "_720p.mp4", 2)
+            val audioFile = File(audioDir, "test_720p.mp4").apply { writeText("audio") }
+            val targetFile = File(outputFolder, "test_720p.mp4")
+
+            val segmentListFileSlot = slot<File>()
+            val mockMediaFile = mockk<MediaFile>()
+            every { ffmpegExecutor.joinSegments(any(), capture(segmentListFileSlot), any(), any()) } returns mockMediaFile
+
+            val operation = SegmentedEncodeService.JoinSegmentOperation(targetFile, segments, audioFile)
+            val encoreJob = defaultEncoreJob().copy(outputFolder = outputFolder.absolutePath, baseName = "test")
+
+            val result = service.joinSegments(encoreJob, workDir, operation)
+
+            assertEquals(mockMediaFile, result)
+            verify { ffmpegExecutor.joinSegments(encoreJob, any(), targetFile, audioFile) }
+            assertSegmentListFileMatches(segmentListFileSlot.captured, File(workDir, "test_720p_filelist.txt"), segments)
+        }
+
+        @Test
+        fun `joins segments without audio file`() {
+            val (outputFolder, workDir) = setupDirectories(tempDir)
+
+            val segments = createSegmentFilesList(workDir, "test", "_720p.mp4", 2)
+            val targetFile = File(outputFolder, "test_720p.mp4")
+
+            val segmentListFileSlot = slot<File>()
+            val mockMediaFile = mockk<MediaFile>()
+            every { ffmpegExecutor.joinSegments(any(), capture(segmentListFileSlot), any(), null) } returns mockMediaFile
+
+            val operation = SegmentedEncodeService.JoinSegmentOperation(targetFile, segments, null)
+            val encoreJob = defaultEncoreJob().copy(outputFolder = outputFolder.absolutePath, baseName = "test")
+
+            val result = service.joinSegments(encoreJob, workDir, operation)
+
+            assertEquals(mockMediaFile, result)
+            verify { ffmpegExecutor.joinSegments(encoreJob, any(), targetFile, null) }
+            assertSegmentListFileMatches(segmentListFileSlot.captured, File(workDir, "test_720p_filelist.txt"), segments)
+        }
+
+        @Test
+        fun `copies audio file when no video segments exist`() {
+            val (outputFolder, workDir) = setupDirectories(tempDir)
+            val audioDir = File(workDir, "audio").apply { mkdirs() }
+
+            val audioFile = File(audioDir, "test_audio.mp4").apply { writeText("audio_only") }
+            val targetFile = File(outputFolder, "test_audio.mp4")
+
+            val mockMediaFile = mockk<MediaFile>()
+            every { mediaAnalyzerService.analyze(targetFile.absolutePath) } returns mockMediaFile
+
+            val operation = SegmentedEncodeService.JoinSegmentOperation(targetFile, emptyList(), audioFile)
+            val encoreJob = defaultEncoreJob().copy(outputFolder = outputFolder.absolutePath, baseName = "test")
+
+            val result = service.joinSegments(encoreJob, workDir, operation)
+
+            assertEquals(mockMediaFile, result)
+            assertEquals("audio_only", targetFile.readText())
+            verify { mediaAnalyzerService.analyze(targetFile.absolutePath) }
+        }
+    }
+}

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/service/segmentedencode/SegmentedEncodeServiceTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/service/segmentedencode/SegmentedEncodeServiceTest.kt
@@ -15,11 +15,17 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import se.svt.oss.encore.config.EncoreProperties
 import se.svt.oss.encore.defaultEncoreJob
+import se.svt.oss.encore.model.AudioEncodingMode
 import se.svt.oss.encore.model.SegmentedEncodingInfo
+import se.svt.oss.encore.model.profile.Profile
+import se.svt.oss.encore.model.profile.SimpleAudioEncode
+import se.svt.oss.encore.model.profile.X264Encode
 import se.svt.oss.encore.model.queue.TaskType
 import se.svt.oss.encore.service.FfmpegExecutor
 import se.svt.oss.encore.service.mediaanalyzer.MediaAnalyzerService
+import se.svt.oss.encore.service.profile.ProfileService
 import se.svt.oss.mediaanalyzer.file.MediaFile
 import java.io.File
 
@@ -27,21 +33,33 @@ class SegmentedEncodeServiceTest {
 
     private val ffmpegExecutor: FfmpegExecutor = mockk()
     private val mediaAnalyzerService: MediaAnalyzerService = mockk()
-    private val service = SegmentedEncodeService(ffmpegExecutor, mediaAnalyzerService)
+    private val profileService: ProfileService = mockk()
+    private val encoreProperties: EncoreProperties = mockk()
+    private val service = SegmentedEncodeService(ffmpegExecutor, mediaAnalyzerService, profileService, encoreProperties)
 
     private fun createJobWithSegmentedEncoding(
         numSegments: Int,
-        segmentedAudioEncode: Boolean,
+        audioEncodingMode: AudioEncodingMode,
         outputFolder: String = "/output/path",
         baseName: String = "test",
+        audioSegmentPadding: Double = 0.0,
+        audioSegmentLength: Double = 0.0,
+        numAudioSegments: Int = when (audioEncodingMode) {
+            AudioEncodingMode.ENCODE_WITH_VIDEO -> 0
+            AudioEncodingMode.ENCODE_SEPARATELY_FULL -> 1
+            AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED -> numSegments
+        },
     ) = defaultEncoreJob().copy(
         outputFolder = outputFolder,
         baseName = baseName,
         segmentedEncodingInfo = SegmentedEncodingInfo(
             segmentLength = 10.0,
             numSegments = numSegments,
-            numTasks = if (segmentedAudioEncode) numSegments else numSegments + 1,
-            segmentedAudioEncode = segmentedAudioEncode,
+            numTasks = numSegments + numAudioSegments,
+            audioEncodingMode = audioEncodingMode,
+            audioSegmentPadding = audioSegmentPadding,
+            audioSegmentLength = audioSegmentLength,
+            numAudioSegments = numAudioSegments,
         ),
     )
 
@@ -64,6 +82,7 @@ class SegmentedEncodeServiceTest {
         expectedTarget: File,
         expectedSegments: List<File>,
         expectedAudio: File? = null,
+        expectedAudioSegments: List<File>? = null,
     ) {
         assertEquals(expectedTarget, operation.target)
         assertEquals(expectedSegments.size, operation.segmentFiles.size)
@@ -74,6 +93,14 @@ class SegmentedEncodeServiceTest {
             assertEquals(expectedAudio, operation.audioFile)
         } else {
             assertNull(operation.audioFile)
+        }
+        if (expectedAudioSegments != null) {
+            assertEquals(expectedAudioSegments.size, operation.audioSegmentFiles?.size)
+            expectedAudioSegments.forEachIndexed { index, expectedFile ->
+                assertEquals(expectedFile, operation.audioSegmentFiles?.get(index))
+            }
+        } else {
+            assertNull(operation.audioSegmentFiles)
         }
     }
 
@@ -95,15 +122,17 @@ class SegmentedEncodeServiceTest {
     @Nested
     inner class CreateTasksTest {
 
-        @ParameterizedTest(name = "numSegments={0}, segmentedAudio={1} creates {2} tasks")
+        @ParameterizedTest(name = "numSegments={0}, audioMode={1} creates {2} tasks")
         @CsvSource(
-            "3, true, 3",
-            "10, true, 10",
-            "3, false, 4",
-            "1, false, 2",
+            "3, ENCODE_WITH_VIDEO, 3",
+            "10, ENCODE_WITH_VIDEO, 10",
+            "3, ENCODE_SEPARATELY_FULL, 4",
+            "1, ENCODE_SEPARATELY_FULL, 2",
+            "3, ENCODE_SEPARATELY_SEGMENTED, 6",
+            "5, ENCODE_SEPARATELY_SEGMENTED, 10",
         )
-        fun `creates correct number of tasks`(numSegments: Int, segmentedAudioEncode: Boolean, expectedTasks: Int) {
-            val encoreJob = createJobWithSegmentedEncoding(numSegments, segmentedAudioEncode)
+        fun `creates correct number of tasks`(numSegments: Int, audioEncodingMode: AudioEncodingMode, expectedTasks: Int) {
+            val encoreJob = createJobWithSegmentedEncoding(numSegments, audioEncodingMode)
 
             val tasks = service.createTasks(encoreJob)
 
@@ -111,8 +140,8 @@ class SegmentedEncodeServiceTest {
         }
 
         @Test
-        fun `creates audio-video segment tasks when audio is segmented`() {
-            val encoreJob = createJobWithSegmentedEncoding(numSegments = 3, segmentedAudioEncode = true)
+        fun `creates audio-video segment tasks when using ENCODE_WITH_VIDEO mode`() {
+            val encoreJob = createJobWithSegmentedEncoding(numSegments = 3, audioEncodingMode = AudioEncodingMode.ENCODE_WITH_VIDEO)
 
             val tasks = service.createTasks(encoreJob)
 
@@ -124,8 +153,8 @@ class SegmentedEncodeServiceTest {
         }
 
         @Test
-        fun `creates separate audio task and video segments when audio is not segmented`() {
-            val encoreJob = createJobWithSegmentedEncoding(numSegments = 3, segmentedAudioEncode = false)
+        fun `creates separate full audio task and video segments when using ENCODE_SEPARATELY_FULL mode`() {
+            val encoreJob = createJobWithSegmentedEncoding(numSegments = 3, audioEncodingMode = AudioEncodingMode.ENCODE_SEPARATELY_FULL)
 
             val tasks = service.createTasks(encoreJob)
 
@@ -138,6 +167,29 @@ class SegmentedEncodeServiceTest {
                 assertEquals(index, task.segment)
             }
         }
+
+        @Test
+        fun `creates audio segments and video segments when using ENCODE_SEPARATELY_SEGMENTED mode`() {
+            val encoreJob = createJobWithSegmentedEncoding(numSegments = 3, audioEncodingMode = AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED)
+
+            val tasks = service.createTasks(encoreJob)
+
+            assertEquals(6, tasks.size)
+
+            // First 3 tasks should be audio segments
+            tasks.take(3).forEachIndexed { index, task ->
+                assertEquals(TaskType.AUDIOSEGMENT, task.type)
+                assertEquals(index, task.taskNo)
+                assertEquals(index, task.segment)
+            }
+
+            // Next 3 tasks should be video segments
+            tasks.drop(3).forEachIndexed { index, task ->
+                assertEquals(TaskType.VIDEOSEGMENT, task.type)
+                assertEquals(index + 3, task.taskNo)
+                assertEquals(index, task.segment)
+            }
+        }
     }
 
     @Nested
@@ -147,13 +199,13 @@ class SegmentedEncodeServiceTest {
         lateinit var tempDir: File
 
         @Test
-        fun `prepares join operations for segmented audio encode`() {
+        fun `prepares join operations for ENCODE_WITH_VIDEO mode`() {
             val (outputFolder, workDir) = setupDirectories(tempDir)
             createSegmentFiles(workDir, "test", listOf("_720p.mp4", "_1080p.mp4"), 3)
 
             val encoreJob = createJobWithSegmentedEncoding(
                 numSegments = 3,
-                segmentedAudioEncode = true,
+                audioEncodingMode = AudioEncodingMode.ENCODE_WITH_VIDEO,
                 outputFolder = outputFolder.absolutePath,
             )
 
@@ -173,7 +225,7 @@ class SegmentedEncodeServiceTest {
         }
 
         @Test
-        fun `prepares join operations for separate audio encode`() {
+        fun `prepares join operations for ENCODE_SEPARATELY_FULL mode`() {
             val (outputFolder, workDir) = setupDirectories(tempDir)
             val audioDir = File(workDir, "audio").apply { mkdirs() }
 
@@ -183,7 +235,7 @@ class SegmentedEncodeServiceTest {
 
             val encoreJob = createJobWithSegmentedEncoding(
                 numSegments = 2,
-                segmentedAudioEncode = false,
+                audioEncodingMode = AudioEncodingMode.ENCODE_SEPARATELY_FULL,
                 outputFolder = outputFolder.absolutePath,
             )
 
@@ -205,13 +257,55 @@ class SegmentedEncodeServiceTest {
         }
 
         @Test
+        fun `prepares join operations for ENCODE_SEPARATELY_SEGMENTED mode`() {
+            val (outputFolder, workDir) = setupDirectories(tempDir)
+            val audioDir = File(workDir, "audio").apply { mkdirs() }
+
+            // Create video segments
+            createSegmentFiles(workDir, "test", listOf("_720p.mp4"), 2)
+            // Create audio segments
+            createSegmentFiles(audioDir, "test", listOf("_720p.mp4"), 2)
+            // Create audio-only segments
+            createSegmentFiles(audioDir, "test", listOf("_audio.mp4"), 2)
+
+            val encoreJob = createJobWithSegmentedEncoding(
+                numSegments = 2,
+                audioEncodingMode = AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED,
+                outputFolder = outputFolder.absolutePath,
+            )
+
+            val operations = service.prepareJoinSegment(encoreJob, workDir)
+
+            // Should have 2 operations:
+            // 1. Video join operation for test_720p.mp4 (with audioSegmentFiles)
+            // 2. Audio-only join operation for test_audio.mp4
+            assertEquals(2, operations.size)
+
+            // Video operation should have audio segment files
+            assertOperationMatches(
+                operations["test_720p.mp4"]!!,
+                expectedTarget = File(outputFolder, "test_720p.mp4"),
+                expectedSegments = expectedSegmentFiles(workDir, "test", "_720p.mp4", 2),
+                expectedAudioSegments = expectedSegmentFiles(audioDir, "test", "_720p.mp4", 2),
+            )
+
+            // Audio-only output
+            assertOperationMatches(
+                operations["test_audio.mp4"]!!,
+                expectedTarget = File(outputFolder, "test_audio.mp4"),
+                expectedSegments = emptyList(),
+                expectedAudioSegments = expectedSegmentFiles(audioDir, "test", "_audio.mp4", 2),
+            )
+        }
+
+        @Test
         fun `groups segment files by suffix correctly`() {
             val (outputFolder, workDir) = setupDirectories(tempDir)
             createSegmentFiles(workDir, "test", listOf(".mp4", "_high.mp4", "_low.mp4"), 2)
 
             val encoreJob = createJobWithSegmentedEncoding(
                 numSegments = 2,
-                segmentedAudioEncode = true,
+                audioEncodingMode = AudioEncodingMode.ENCODE_WITH_VIDEO,
                 outputFolder = outputFolder.absolutePath,
             )
 
@@ -253,7 +347,7 @@ class SegmentedEncodeServiceTest {
 
             val segmentListFileSlot = slot<File>()
             val mockMediaFile = mockk<MediaFile>()
-            every { ffmpegExecutor.joinSegments(any(), capture(segmentListFileSlot), any(), any()) } returns mockMediaFile
+            every { ffmpegExecutor.joinSegments(any(), capture(segmentListFileSlot), any(), any(), any()) } returns mockMediaFile
 
             val operation = SegmentedEncodeService.JoinSegmentOperation(targetFile, segments, audioFile)
             val encoreJob = defaultEncoreJob().copy(outputFolder = outputFolder.absolutePath, baseName = "test")
@@ -261,7 +355,7 @@ class SegmentedEncodeServiceTest {
             val result = service.joinSegments(encoreJob, workDir, operation)
 
             assertEquals(mockMediaFile, result)
-            verify { ffmpegExecutor.joinSegments(encoreJob, any(), targetFile, audioFile) }
+            verify { ffmpegExecutor.joinSegments(encoreJob, any(), targetFile, audioFile, null) }
             assertSegmentListFileMatches(segmentListFileSlot.captured, File(workDir, "test_720p_filelist.txt"), segments)
         }
 
@@ -274,7 +368,7 @@ class SegmentedEncodeServiceTest {
 
             val segmentListFileSlot = slot<File>()
             val mockMediaFile = mockk<MediaFile>()
-            every { ffmpegExecutor.joinSegments(any(), capture(segmentListFileSlot), any(), null) } returns mockMediaFile
+            every { ffmpegExecutor.joinSegments(any(), capture(segmentListFileSlot), any(), null, any()) } returns mockMediaFile
 
             val operation = SegmentedEncodeService.JoinSegmentOperation(targetFile, segments, null)
             val encoreJob = defaultEncoreJob().copy(outputFolder = outputFolder.absolutePath, baseName = "test")
@@ -282,7 +376,7 @@ class SegmentedEncodeServiceTest {
             val result = service.joinSegments(encoreJob, workDir, operation)
 
             assertEquals(mockMediaFile, result)
-            verify { ffmpegExecutor.joinSegments(encoreJob, any(), targetFile, null) }
+            verify { ffmpegExecutor.joinSegments(encoreJob, any(), targetFile, null, null) }
             assertSegmentListFileMatches(segmentListFileSlot.captured, File(workDir, "test_720p_filelist.txt"), segments)
         }
 
@@ -305,6 +399,371 @@ class SegmentedEncodeServiceTest {
             assertEquals(mockMediaFile, result)
             assertEquals("audio_only", targetFile.readText())
             verify { mediaAnalyzerService.analyze(targetFile.absolutePath) }
+        }
+
+        @Test
+        fun `joins audio segments with padding`() {
+            val (outputFolder, workDir) = setupDirectories(tempDir)
+            val audioDir = File(workDir, "audio").apply { mkdirs() }
+
+            val audioSegments = createSegmentFilesList(audioDir, "test", "_audio.mp4", 3)
+            val targetFile = File(outputFolder, "test_audio.mp4")
+
+            val mockMediaFile = mockk<MediaFile>()
+            val capturedSegmentList = slot<File>()
+            every { ffmpegExecutor.joinSegments(any(), capture(capturedSegmentList), any(), null, null) } returns mockMediaFile
+
+            val operation = SegmentedEncodeService.JoinSegmentOperation(targetFile, emptyList(), null, audioSegments)
+            val encoreJob = defaultEncoreJob().copy(
+                outputFolder = outputFolder.absolutePath,
+                baseName = "test",
+                segmentedEncodingInfo = SegmentedEncodingInfo(
+                    segmentLength = 10.0,
+                    numSegments = 3,
+                    numTasks = 3,
+                    audioEncodingMode = AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED,
+                    audioSegmentPadding = 2 * 8.0 / 375.0, // 2 audio frames for 48khz
+                    audioSegmentLength = 8.0,
+                    numAudioSegments = 4,
+                ),
+            )
+
+            val result = service.joinSegments(encoreJob, workDir, operation)
+
+            assertEquals(mockMediaFile, result)
+            verify { ffmpegExecutor.joinSegments(encoreJob, any(), targetFile, null, null) }
+
+            // Verify the audio segment list file was created with proper padding
+            val audioSegmentListFile = capturedSegmentList.captured
+            assertEquals(true, audioSegmentListFile.exists())
+
+            val expectedContent = """
+                file ${audioSegments[0].absolutePath}
+                inpoint 0.0
+                outpoint 8.0
+                file ${audioSegments[1].absolutePath}
+                inpoint 0.042666666666666665
+                outpoint 8.042666666666667
+                file ${audioSegments[2].absolutePath}
+                inpoint 0.042666666666666665
+                
+            """.trimIndent()
+
+            assertEquals(expectedContent, audioSegmentListFile.readText())
+        }
+
+        @Test
+        fun `joins video segments with audio segment list`() {
+            val (outputFolder, workDir) = setupDirectories(tempDir)
+            val audioDir = File(workDir, "audio").apply { mkdirs() }
+
+            val videoSegments = createSegmentFilesList(workDir, "test", "_720p.mp4", 2)
+            val audioSegments = createSegmentFilesList(audioDir, "test", "_720p.mp4", 2)
+            val targetFile = File(outputFolder, "test_720p.mp4")
+
+            val mockMediaFile = mockk<MediaFile>()
+            val capturedAudioSegmentList = slot<File>()
+            every {
+                ffmpegExecutor.joinSegments(any(), any(), any(), null, capture(capturedAudioSegmentList))
+            } returns mockMediaFile
+
+            val operation = SegmentedEncodeService.JoinSegmentOperation(targetFile, videoSegments, null, audioSegments)
+            val encoreJob = defaultEncoreJob().copy(
+                outputFolder = outputFolder.absolutePath,
+                baseName = "test",
+                segmentedEncodingInfo = SegmentedEncodingInfo(
+                    segmentLength = 10.0,
+                    numSegments = 2,
+                    numTasks = 4,
+                    audioEncodingMode = AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED,
+                    audioSegmentPadding = 0.2,
+                    audioSegmentLength = 8.0,
+                    numAudioSegments = 2,
+                ),
+            )
+
+            val result = service.joinSegments(encoreJob, workDir, operation)
+
+            assertEquals(mockMediaFile, result)
+            verify { ffmpegExecutor.joinSegments(encoreJob, any(), targetFile, null, any()) }
+
+            // Verify the audio segment list file was created
+            val audioSegmentListFile = capturedAudioSegmentList.captured
+            assertEquals(true, audioSegmentListFile.exists())
+        }
+    }
+
+    @Nested
+    inner class AudioEncodingModeTest {
+
+        private fun setupEncoreProperties(audioEncodingMode: AudioEncodingMode) {
+            val segmentedEncodingProps = mockk<se.svt.oss.encore.config.SegmentedEncodingProperties> {
+                every { this@mockk.audioEncodingMode } returns audioEncodingMode
+            }
+            val encodingProps = mockk<se.svt.oss.encore.config.EncodingProperties> {
+                every { segmentedEncoding } returns segmentedEncodingProps
+            }
+            every { encoreProperties.encoding } returns encodingProps
+        }
+
+        @Test
+        fun `returns nulls for ENCODE_WITH_VIDEO mode`() {
+            val profile = Profile(
+                name = "test",
+                description = "test",
+                encodes = listOf(
+                    se.svt.oss.encore.model.profile.AudioEncode(samplerate = 48000),
+                ),
+            )
+            every { profileService.getProfile(any()) } returns profile
+            setupEncoreProperties(AudioEncodingMode.ENCODE_WITH_VIDEO)
+
+            val job = defaultEncoreJob()
+            val config = service.audioEncodingConfig(job, profile)
+
+            assertEquals(AudioEncodingMode.ENCODE_WITH_VIDEO, config.audioEncodingMode)
+            assertEquals(0.0, config.audioSegmentPadding, 0.0001)
+            assertEquals(0.0, config.audioSegmentLength, 0.0001)
+        }
+
+        @Test
+        fun `returns nulls for ENCODE_SEPARATELY_FULL mode`() {
+            val profile = Profile(
+                name = "test",
+                description = "test",
+                encodes = listOf(
+                    se.svt.oss.encore.model.profile.AudioEncode(samplerate = 48000),
+                ),
+            )
+            every { profileService.getProfile(any()) } returns profile
+            setupEncoreProperties(AudioEncodingMode.ENCODE_SEPARATELY_FULL)
+
+            val job = defaultEncoreJob()
+            val config = service.audioEncodingConfig(job, profile)
+
+            assertEquals(AudioEncodingMode.ENCODE_SEPARATELY_FULL, config.audioEncodingMode)
+            assertEquals(0.0, config.audioSegmentPadding, 0.0001)
+            assertEquals(0.0, config.audioSegmentLength, 0.0001)
+        }
+
+        @Test
+        fun `downgrades to ENCODE_WITH_VIDEO when no audio encodes`() {
+            val profile = Profile(
+                name = "test",
+                description = "test",
+                encodes = listOf(
+                    X264Encode(width = 1920, height = 1080, twoPass = false, suffix = "_test"),
+                ),
+            )
+            every { profileService.getProfile(any()) } returns profile
+            setupEncoreProperties(AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED)
+
+            val job = defaultEncoreJob()
+            val config = service.audioEncodingConfig(job, profile)
+
+            assertEquals(AudioEncodingMode.ENCODE_WITH_VIDEO, config.audioEncodingMode)
+            assertEquals(0.0, config.audioSegmentPadding, 0.0001)
+            assertEquals(0.0, config.audioSegmentLength, 0.0001)
+        }
+
+        @Test
+        fun `downgrades to ENCODE_SEPARATELY_FULL when multiple sample rates with ENCODE_SEPARATELY_SEGMENTED`() {
+            val profile = Profile(
+                name = "test",
+                description = "test",
+                encodes = listOf(
+                    se.svt.oss.encore.model.profile.AudioEncode(samplerate = 48000),
+                    se.svt.oss.encore.model.profile.AudioEncode(samplerate = 44100),
+                ),
+            )
+            every { profileService.getProfile(any()) } returns profile
+            setupEncoreProperties(AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED)
+
+            val job = defaultEncoreJob()
+            val config = service.audioEncodingConfig(job, profile)
+
+            assertEquals(AudioEncodingMode.ENCODE_SEPARATELY_FULL, config.audioEncodingMode)
+            assertEquals(0.0, config.audioSegmentPadding, 0.0001)
+            assertEquals(0.0, config.audioSegmentLength, 0.0001)
+        }
+
+        @Test
+        fun `calculates audioSegmentPadding for ENCODE_SEPARATELY_SEGMENTED with single sample rate`() {
+            val profile = Profile(
+                name = "test",
+                description = "test",
+                encodes = listOf(
+                    se.svt.oss.encore.model.profile.AudioEncode(samplerate = 48000),
+                ),
+            )
+            every { profileService.getProfile(any()) } returns profile
+            setupEncoreProperties(AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED)
+
+            val job = defaultEncoreJob()
+            val config = service.audioEncodingConfig(job, profile)
+
+            assertEquals(AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED, config.audioEncodingMode)
+            // audioSegmentPadding = 2 * 1024 / 48000 = 0.04266...
+            assertEquals(2.0 * 1024.0 / 48000.0, config.audioSegmentPadding, 0.0001)
+        }
+
+        @Test
+        fun `calculates audioSegmentLength close to 256s for ENCODE_SEPARATELY_SEGMENTED`() {
+            val profile = Profile(
+                name = "test",
+                description = "test",
+                encodes = listOf(
+                    se.svt.oss.encore.model.profile.AudioEncode(samplerate = 48000),
+                ),
+            )
+            every { profileService.getProfile(any()) } returns profile
+            setupEncoreProperties(AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED)
+
+            val job = defaultEncoreJob()
+            val config = service.audioEncodingConfig(job, profile)
+
+            assertEquals(AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED, config.audioEncodingMode)
+            // Should be close to 256s and a multiple of frame duration (1024 / 48000 = 0.021333...)
+            val frameDuration = 1024.0 / 48000.0
+            val expectedLength = kotlin.math.round(256.0 / frameDuration) * frameDuration
+            assertEquals(expectedLength, config.audioSegmentLength, 0.0001)
+            // Verify it's actually close to 256s
+            assertEquals(256.0, config.audioSegmentLength, 0.1)
+        }
+
+        @Test
+        fun `uses custom audioSegmentLength from job when specified`() {
+            val profile = Profile(
+                name = "test",
+                description = "test",
+                encodes = listOf(
+                    se.svt.oss.encore.model.profile.AudioEncode(samplerate = 48000),
+                ),
+            )
+            every { profileService.getProfile(any()) } returns profile
+            setupEncoreProperties(AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED)
+
+            val customLength = 300.0
+            val job = defaultEncoreJob().copy(audioSegmentLength = customLength)
+            val config = service.audioEncodingConfig(job, profile)
+
+            assertEquals(AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED, config.audioEncodingMode)
+            assertEquals(customLength, config.audioSegmentLength)
+        }
+
+        @Test
+        fun `uses job audioEncodingMode when specified`() {
+            val profile = Profile(
+                name = "test",
+                description = "test",
+                encodes = listOf(
+                    se.svt.oss.encore.model.profile.AudioEncode(samplerate = 48000),
+                ),
+            )
+            every { profileService.getProfile(any()) } returns profile
+            setupEncoreProperties(AudioEncodingMode.ENCODE_WITH_VIDEO)
+
+            val job = defaultEncoreJob().copy(audioEncodingMode = AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED)
+            val config = service.audioEncodingConfig(job, profile)
+
+            assertEquals(AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED, config.audioEncodingMode)
+        }
+
+        @Test
+        fun `downgrades when multiple sample rates within same output`() {
+            val profile = Profile(
+                name = "test",
+                description = "test",
+                encodes = listOf(
+                    se.svt.oss.encore.model.profile.GenericVideoEncode(
+                        width = null,
+                        height = 720,
+                        twoPass = false,
+                        params = linkedMapOf(),
+                        audioEncode = null,
+                        audioEncodes = listOf(
+                            se.svt.oss.encore.model.profile.SimpleAudioEncode(samplerate = 48000),
+                            se.svt.oss.encore.model.profile.SimpleAudioEncode(samplerate = 44100),
+                        ),
+                        suffix = "_test",
+                        format = "mp4",
+                        codec = "libx264",
+                    ),
+                ),
+            )
+            every { profileService.getProfile(any()) } returns profile
+            setupEncoreProperties(AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED)
+
+            val job = defaultEncoreJob()
+            val config = service.audioEncodingConfig(job, profile)
+
+            // Should downgrade to ENCODE_SEPARATELY_FULL because multiple sample rates are present
+            assertEquals(AudioEncodingMode.ENCODE_SEPARATELY_FULL, config.audioEncodingMode)
+            assertEquals(0.0, config.audioSegmentPadding, 0.0001)
+            assertEquals(0.0, config.audioSegmentLength, 0.0001)
+        }
+
+        @Test
+        fun `uses default sample rate of 48000 when no sample rates found`() {
+            val profile = Profile(
+                name = "test",
+                description = "test",
+                encodes = listOf(
+                    se.svt.oss.encore.model.profile.GenericVideoEncode(
+                        width = null,
+                        height = 720,
+                        twoPass = false,
+                        params = linkedMapOf(),
+                        audioEncode = SimpleAudioEncode(),
+                        suffix = "_test",
+                        format = "mp4",
+                        codec = "libx264",
+                    ),
+                ),
+            )
+            every { profileService.getProfile(any()) } returns profile
+            setupEncoreProperties(AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED)
+
+            val job = defaultEncoreJob()
+            val config = service.audioEncodingConfig(job, profile)
+
+            // Should use default 48000
+            assertEquals(2.0 * 1024.0 / 48000.0, config.audioSegmentPadding, 0.0001)
+        }
+
+        @Test
+        fun `calculates different padding for different sample rates`() {
+            // Test with 44100 Hz
+            val profile44100 = Profile(
+                name = "test",
+                description = "test",
+                encodes = listOf(
+                    se.svt.oss.encore.model.profile.AudioEncode(samplerate = 44100),
+                ),
+            )
+            every { profileService.getProfile(any()) } returns profile44100
+            setupEncoreProperties(AudioEncodingMode.ENCODE_SEPARATELY_SEGMENTED)
+
+            val job1 = defaultEncoreJob()
+            val config1 = service.audioEncodingConfig(job1, profile44100)
+            assertEquals(2.0 * 1024.0 / 44100.0, config1.audioSegmentPadding, 0.0001)
+
+            // Test with 96000 Hz
+            val profile96000 = Profile(
+                name = "test",
+                description = "test",
+                encodes = listOf(
+                    se.svt.oss.encore.model.profile.AudioEncode(samplerate = 96000),
+                ),
+            )
+            every { profileService.getProfile(any()) } returns profile96000
+
+            val job2 = defaultEncoreJob()
+            val config2 = service.audioEncodingConfig(job2, profile96000)
+            assertEquals(2.0 * 1024.0 / 96000.0, config2.audioSegmentPadding, 0.0001)
+
+            // Higher sample rate should have smaller padding
+            assert(config2.audioSegmentPadding < config1.audioSegmentPadding)
         }
     }
 }

--- a/encore-common/src/test/resources/profile/audio-only.yml
+++ b/encore-common/src/test/resources/profile/audio-only.yml
@@ -1,0 +1,14 @@
+name: audio-only
+description: Audio-only profile for testing segmented audio encoding
+encodes:
+  - type: AudioEncode
+    bitrate: 128k
+    suffix: _STEREO
+
+  - type: AudioEncode
+    bitrate: 128k
+    suffix: _STEREO_DE
+    dialogueEnhancement:
+      enabled: true
+    audioMixPreset: de
+    optional: true

--- a/encore-common/src/test/resources/profile/profiles.yml
+++ b/encore-common/src/test/resources/profile/profiles.yml
@@ -4,6 +4,7 @@ dpb_size_failed: dpb_size_failed.yml
 program-x265: program-x265.yml
 archive: archive.yml
 audio-streams: audio-streams.yml
+audio-only: audio-only.yml
 test-invalid: test_profile_invalid.yml
 test-invalid-location: test_profile_invalid_location.yml
 separate-video-audio: separate-video-audio.yml

--- a/encore-common/src/test/resources/profile/separate-video-audio.yml
+++ b/encore-common/src/test/resources/profile/separate-video-audio.yml
@@ -39,6 +39,7 @@ encodes:
     suffix: _SURROUND
     optional: true
     channelLayout: '5.1'
+    enabled: #{profileParams['enableSurround'] ?: 'true'}
 
   - type: AudioEncode
     codec: ac3
@@ -49,3 +50,4 @@ encodes:
     audioMixPreset: de
     optional: true
     channelLayout: '5.1'
+    enabled: #{profileParams['enableSurround'] ?: 'true'}


### PR DESCRIPTION
feat: implement segmented audio encoding
    
    Introduces support for encoding audio separately from video in segments,
    enabling better parallelization and throughput for large files.
    
    There are now three modes for audio encoding when using segmented encoding:
    
    1. ENCODE_WITH_VIDEO (default) -Audio is encoded together with each video segment
    2. ENCODE_SEPARATELY_FULL - Audio is encoded once as a complete file,
    then muxed with video segments
    3. ENCODE_SEPARATELY_SEGMENTED - Audio is split into segments and encoded in parallel with video
    
    Audio encoding mode can be selected with the 'encoreJob.audioEncodingMode' property.
    A default value, used when the property is not specified on the job, can be configured
    with the 'encore-settings.encoding.segmented-encoding.audio-encoding-mode' property.
    
    For segmented audio encode, audio segment length can be configured with the
    property 'encoreJob.audioSegmentLength' . Note that the segment length needs
    to be a multiple of the audio frame duration for proper encoding. If audio
    segment length is not specified, a suitable segment length close to 256s will
    be calculated.
