### PR TITLE
fix: handle errors during job initialization

### DIFF
--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/EncoreService.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/EncoreService.kt
@@ -85,7 +85,16 @@ class EncoreService(
             ?: throw IllegalStateException("Shared work dir has not been configured")
 
     fun encode(queueItem: QueueItem, job: EncoreJob) {
-        initJob(job)
+        try {
+            initJob(job)
+        } catch (e: Exception) {
+            log.error(e) { "Job initialization failed: ${e.message}" }
+            job.status = Status.FAILED
+            job.message = e.message
+            repository.save(job)
+            callbackService.sendProgressCallback(job)
+            return
+        }
         when {
             queueItem.task != null -> encodeSegment(job, queueItem.task)
             job.segmentedEncodingInfo != null -> encodeSegmented(job)

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/EncoreIntegrationTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/EncoreIntegrationTest.kt
@@ -374,4 +374,19 @@ class EncoreIntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo) : EncoreIn
             .hasNumSegments(0) // No video segments
             .hasNumTasks(2) // Only 2 audio segments
     }
+
+    @Test
+    fun jobIsFailedOnUnknownProfile(@TempDir outputDir: File) {
+        val createdJob = createAndAwaitJob(
+            job = job(outputDir).copy(profile = "unknown_profile"),
+            pollInterval = Durations.ONE_SECOND,
+            timeout = Durations.ONE_MINUTE,
+        ) { it.status.isCompleted }
+
+        assertThat(createdJob)
+            .hasStatus(Status.FAILED)
+
+        assertThat(createdJob.message)
+            .contains("Could not find location for profile unknown_profile!")
+    }
 }


### PR DESCRIPTION
Errors during job initialization were previously not handled, which could result in a job being stuck in QUEUED state forever. Specifically, a job with an invalid/unknown profile would be stuck in this state. This fix now correcly handles error in these cases and sets the job status to FAILED.