### PR TITLE
feat: s3 input and/or output can now be used with chunked encoding

### DIFF
--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/input/Input.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/input/Input.kt
@@ -161,6 +161,8 @@ data class AudioInput(
     override val channelLayout: ChannelLayout? = null,
     override val seekTo: Double? = null,
     override val copyTs: Boolean = false,
+    @JsonIgnore
+    override var accessUri: String = uri,
 ) : AudioIn {
     override val analyzedAudio: MediaContainer
         @JsonIgnore
@@ -168,9 +170,6 @@ data class AudioInput(
 
     override val type: String
         get() = TYPE_AUDIO
-
-    @JsonIgnore
-    override var accessUri: String = uri
 
     override fun withSeekTo(seekTo: Double) = copy(seekTo = seekTo)
 
@@ -192,9 +191,9 @@ data class VideoInput(
     override val probeInterlaced: Boolean = true,
     override val seekTo: Double? = null,
     override val copyTs: Boolean = false,
-) : VideoIn {
     @JsonIgnore
-    override var accessUri: String = uri
+    override var accessUri: String = uri,
+) : VideoIn {
 
     override val analyzedVideo: VideoFile
         @JsonIgnore
@@ -227,10 +226,10 @@ data class AudioVideoInput(
     override val channelLayout: ChannelLayout? = null,
     override val seekTo: Double? = null,
     override val copyTs: Boolean = false,
+    @JsonIgnore
+    override var accessUri: String = uri,
 ) : VideoIn,
     AudioIn {
-    @JsonIgnore
-    override var accessUri: String = uri
 
     override val analyzedVideo: VideoFile
         @JsonIgnore

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/EncoreService.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/EncoreService.kt
@@ -106,6 +106,7 @@ class EncoreService(
         val coroutineJob = Job()
         val cancelListener = CancellationListener(objectMapper, encoreJob.id, coroutineJob)
         var progressListener: SegmentProgressListener? = null
+        var outputFolder: String? = null
         try {
             startJob(encoreJob)
             val tasks = segmentedEncodeService.createTasks(encoreJob)
@@ -143,7 +144,10 @@ class EncoreService(
                     throw RuntimeException("Some segments failed")
                 }
                 log.info { "All segments completed" }
-                segmentedEncodeService.joinSegments(encoreJob, sharedWorkDir(encoreJob))
+                outputFolder = localEncodeService.outputFolder(encoreJob)
+                File(outputFolder).mkdirs()
+                val outputFiles = segmentedEncodeService.joinSegments(encoreJob, outputFolder!!, sharedWorkDir(encoreJob))
+                localEncodeService.localEncodedFilesToCorrectDir(outputFolder!!, outputFiles, encoreJob)
             }
             updateSuccessfulJob(encoreJob, timedOutput)
         } catch (e: CancellationException) {
@@ -167,12 +171,16 @@ class EncoreService(
             redisMessageListerenerContainer.removeMessageListener(cancelListener)
             progressListener?.let { redisMessageListerenerContainer.removeMessageListener(it) }
             callbackService.sendProgressCallback(encoreJob)
+            localEncodeService.cleanup(outputFolder, encoreJob)
         }
     }
 
     private fun encodeSegment(encoreJob: EncoreJob, task: Task) {
         val taskNo = task.taskNo
         try {
+            encoreJob.inputs.forEach { input ->
+                input.accessUri = remoteFileService.getAccessUri(input.uri)
+            }
             log.info { "Start encoding ${encoreJob.baseName} task $taskNo/${encoreJob.segmentedEncodingInfo?.numTasks} (${task.type})" }
             val encodingMode = when (task.type) {
                 TaskType.AUDIOFULL -> EncodingMode.AUDIO_ONLY

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/segmentedencode/SegmentedEncodeService.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/segmentedencode/SegmentedEncodeService.kt
@@ -251,7 +251,7 @@ class SegmentedEncodeService(
         val audioSegmentFiles: List<File>? = null,
     )
 
-    fun prepareJoinSegment(encoreJob: EncoreJob, sharedWorkDir: File): Map<String, JoinSegmentOperation> {
+    fun prepareJoinSegment(encoreJob: EncoreJob, outputFolder: File, sharedWorkDir: File): Map<String, JoinSegmentOperation> {
         val segmentedEncodingInfo = encoreJob.segmentedEncodingInfoOrThrow()
         val audioEncodingMode = segmentedEncodingInfo.audioEncodingMode
 
@@ -279,8 +279,6 @@ class SegmentedEncodeService(
             emptyMap()
         }
 
-        val outputFolder = File(encoreJob.outputFolder)
-        outputFolder.mkdirs()
         val joinSegmentOperations = LinkedHashMap<String, JoinSegmentOperation>()
 
         // Handle video segments and determine corresponding audio
@@ -324,8 +322,8 @@ class SegmentedEncodeService(
         return joinSegmentOperations
     }
 
-    fun joinSegments(encoreJob: EncoreJob, sharedWorkDir: File): List<MediaFile> {
-        val joinSegmentOperations = prepareJoinSegment(encoreJob, sharedWorkDir)
+    fun joinSegments(encoreJob: EncoreJob, outputFolder: String, sharedWorkDir: File): List<MediaFile> {
+        val joinSegmentOperations = prepareJoinSegment(encoreJob, File(outputFolder), sharedWorkDir)
 
         return joinSegmentOperations.values.map { joinSegmentOperation ->
             joinSegments(encoreJob, sharedWorkDir, joinSegmentOperation)

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/EncoreIntegrationTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/EncoreIntegrationTest.kt
@@ -27,7 +27,8 @@ import java.time.Duration
 class EncoreIntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo) : EncoreIntegrationTestBase(wireMockRuntimeInfo) {
 
     @Test
-    fun jobIsSuccessfulSurround(@TempDir outputDir: File) {
+    fun jobIsSuccessfulSurround(@TempDir tempDir: File) {
+        val outputDir = tempDir.resolve("output")
         val createdJob = successfulTest(
             job(outputDir = outputDir, file = testFileSurround),
             defaultExpectedOutputFiles(outputDir, testFileSurround) +
@@ -40,7 +41,8 @@ class EncoreIntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo) : EncoreIn
     }
 
     @Test
-    fun jobIsSuccessfulSurroundSegmentedEncode(@TempDir outputDir: File) {
+    fun jobIsSuccessfulSurroundSegmentedEncode(@TempDir tempDir: File) {
+        val outputDir = tempDir.resolve("output")
         val job = job(outputDir = outputDir, file = testFileSurround).copy(
             profile = "separate-video-audio",
             segmentLength = 3.84,

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/EncoreS3IntegrationTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/EncoreS3IntegrationTest.kt
@@ -61,7 +61,7 @@ abstract class EncoreS3IntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo)
         }
     }
 
-    fun jobWiths3InputAndOutputIsSuccessful(@TempDir outputDir: File) {
+    fun jobWithS3InputAndOutputIsSuccessful(@TempDir outputDir: File) {
         val filename = "test.mp4"
         val remoteInput = uploadInputfile(testFileSurround.file.absolutePath, filename)
 
@@ -84,7 +84,13 @@ abstract class EncoreS3IntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo)
         assertThat(progressCalls.first())
             .hasStatus(Status.SUCCESSFUL)
 
-        val expectedFiles = (defaultExpectedOutputFileSuffixes() + listOf("SURROUND.mp4"))
+        val expectedFiles = (
+            defaultExpectedOutputFileSuffixes() + listOf(
+                "STEREO_DE.mp4",
+                "SURROUND.mp4",
+                "SURROUND_DE.mp4",
+            )
+            )
             .map { "output/${createdJob.baseName}_$it" }
 
         val actualFiles = s3Client.listObjectsV2 {
@@ -98,6 +104,50 @@ abstract class EncoreS3IntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo)
         // expectedFiles.forEach { minioClient.statObject(StatObjectArgs.builder().bucket(outputBucket).`object`(it).build()) }
     }
 
+    fun jobWithS3InputAndOutputSegmentedEncodeIsSuccessful(@TempDir outputDir: File) {
+        val filename = "test.mp4"
+        val remoteInput = uploadInputfile(testFileSurround.file.absolutePath, filename)
+
+        val job = job(outputDir = outputDir, file = testFileSurround)
+            .copy(
+                outputFolder = "s3://$outputBucket/output/",
+                inputs = listOf(AudioVideoInput(uri = remoteInput)),
+                profile = "separate-video-audio",
+                segmentLength = 3.84,
+                priority = 100,
+            )
+
+        val createdJob = createAndAwaitJob(
+            job = job,
+            timeout = Durations.FIVE_MINUTES,
+        ) { it.status.isCompleted }
+
+        assertThat(createdJob).hasStatus(Status.SUCCESSFUL)
+
+        val expectedFiles = listOf(
+            "x264_3100.mp4",
+            "STEREO.mp4",
+            "STEREO_DE.mp4",
+            "SURROUND.mp4",
+            "SURROUND_DE.mp4",
+        ).map { "output/${createdJob.baseName}_$it" }
+
+        val actualFiles = s3Client.listObjectsV2 {
+            it.bucket(outputBucket)
+                .prefix("output/")
+        }
+            .get()
+            .contents()
+            .map { it.key() ?: "" }
+        assertThat(actualFiles).containsExactlyInAnyOrder(*expectedFiles.toTypedArray())
+
+        assertThat(createdJob.segmentedEncodingInfo)
+            .hasAudioEncodingMode(se.svt.oss.encore.model.AudioEncodingMode.ENCODE_WITH_VIDEO)
+            .hasNumSegments(3)
+            .hasNumAudioSegments(0)
+            .hasNumTasks(3)
+    }
+
     private fun uploadInputfile(localPath: String, key: String): String {
         s3Client.putObject({ it.bucket(inputBucket).key(key).build() }, Paths.get(localPath))
 
@@ -105,17 +155,22 @@ abstract class EncoreS3IntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo)
     }
 
     @Nested
-    @ActiveProfiles(profiles = ["test-local", "test-s3"])
+    @ActiveProfiles(profiles = ["test", "test-s3"])
     @WireMockTest
     class StandardS3Access(wireMockRuntimeInfo: WireMockRuntimeInfo) : EncoreS3IntegrationTest(wireMockRuntimeInfo) {
         @Test
-        fun jobWithS3InputAndOutputIsSuccessful(@TempDir outputDir: File) {
-            super.jobWiths3InputAndOutputIsSuccessful(outputDir)
+        override fun jobWithS3InputAndOutputIsSuccessful(@TempDir outputDir: File) {
+            super.jobWithS3InputAndOutputIsSuccessful(outputDir)
+        }
+
+        @Test
+        override fun jobWithS3InputAndOutputSegmentedEncodeIsSuccessful(@TempDir outputDir: File) {
+            super.jobWithS3InputAndOutputSegmentedEncodeIsSuccessful(outputDir)
         }
     }
 
     @Nested
-    @ActiveProfiles(profiles = ["test-local", "test-s3"])
+    @ActiveProfiles(profiles = ["test", "test-s3"])
     @TestPropertySource(
         properties = [
             "remote-files.s3.anonymous-access=true",
@@ -125,8 +180,13 @@ abstract class EncoreS3IntegrationTest(wireMockRuntimeInfo: WireMockRuntimeInfo)
     @WireMockTest
     class AnonymousS3Access(wireMockRuntimeInfo: WireMockRuntimeInfo) : EncoreS3IntegrationTest(wireMockRuntimeInfo) {
         @Test
-        fun jobWithS3InputAndOutputIsSuccessful(@TempDir outputDir: File) {
-            super.jobWiths3InputAndOutputIsSuccessful(outputDir)
+        override fun jobWithS3InputAndOutputIsSuccessful(@TempDir outputDir: File) {
+            super.jobWithS3InputAndOutputIsSuccessful(outputDir)
+        }
+
+        @Test
+        override fun jobWithS3InputAndOutputSegmentedEncodeIsSuccessful(@TempDir outputDir: File) {
+            super.jobWithS3InputAndOutputSegmentedEncodeIsSuccessful(outputDir)
         }
     }
 }

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/service/segmentedencode/SegmentedEncodeServiceTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/service/segmentedencode/SegmentedEncodeServiceTest.kt
@@ -209,7 +209,7 @@ class SegmentedEncodeServiceTest {
                 outputFolder = outputFolder.absolutePath,
             )
 
-            val operations = service.prepareJoinSegment(encoreJob, workDir)
+            val operations = service.prepareJoinSegment(encoreJob, outputFolder, workDir)
 
             assertEquals(2, operations.size)
             assertOperationMatches(
@@ -239,7 +239,7 @@ class SegmentedEncodeServiceTest {
                 outputFolder = outputFolder.absolutePath,
             )
 
-            val operations = service.prepareJoinSegment(encoreJob, workDir)
+            val operations = service.prepareJoinSegment(encoreJob, outputFolder, workDir)
 
             assertEquals(2, operations.size)
             assertOperationMatches(
@@ -274,7 +274,7 @@ class SegmentedEncodeServiceTest {
                 outputFolder = outputFolder.absolutePath,
             )
 
-            val operations = service.prepareJoinSegment(encoreJob, workDir)
+            val operations = service.prepareJoinSegment(encoreJob, outputFolder, workDir)
 
             // Should have 2 operations:
             // 1. Video join operation for test_720p.mp4 (with audioSegmentFiles)
@@ -309,7 +309,7 @@ class SegmentedEncodeServiceTest {
                 outputFolder = outputFolder.absolutePath,
             )
 
-            val operations = service.prepareJoinSegment(encoreJob, workDir)
+            val operations = service.prepareJoinSegment(encoreJob, outputFolder, workDir)
 
             assertEquals(3, operations.size)
             assertOperationMatches(


### PR DESCRIPTION
Note that mounted shared storage is still required for the shared work dir when using chunked encoding.