### PR TITLE
chore: bump spring boot dependencies to 3.5.9

### DIFF
--- a/buildSrc/src/main/kotlin/encore.kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/encore.kotlin-conventions.gradle.kts
@@ -64,7 +64,7 @@ tasks.test {
 }
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.boot:spring-boot-dependencies:3.5.5")
+        mavenBom("org.springframework.boot:spring-boot-dependencies:3.5.9")
         mavenBom("org.springframework.cloud:spring-cloud-dependencies:2025.0.0")
     }
 }

--- a/buildSrc/src/main/kotlin/encore.spring-boot-app-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/encore.spring-boot-app-conventions.gradle.kts
@@ -17,7 +17,7 @@ tasks.named<BootJar>("bootJar") {
 }
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.boot:spring-boot-dependencies:3.5.5")
+        mavenBom("org.springframework.boot:spring-boot-dependencies:3.5.9")
         mavenBom("org.springframework.cloud:spring-cloud-dependencies:2025.0.0")
     }
 }


### PR DESCRIPTION
There are vulnerabilities in the tomcat version currently in use. By bumping spring-boot-dependencies from 3.5.5 to 3.5.9, we should resolve this.