### PR TITLE
chore: bump spring boot dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/encore.kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/encore.kotlin-conventions.gradle.kts
@@ -64,7 +64,7 @@ tasks.test {
 }
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.boot:spring-boot-dependencies:3.5.9")
+        mavenBom("org.springframework.boot:spring-boot-dependencies:3.5.14")
         mavenBom("org.springframework.cloud:spring-cloud-dependencies:2025.0.0")
     }
 }

--- a/buildSrc/src/main/kotlin/encore.spring-boot-app-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/encore.spring-boot-app-conventions.gradle.kts
@@ -17,7 +17,7 @@ tasks.named<BootJar>("bootJar") {
 }
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.boot:spring-boot-dependencies:3.5.9")
+        mavenBom("org.springframework.boot:spring-boot-dependencies:3.5.14")
         mavenBom("org.springframework.cloud:spring-cloud-dependencies:2025.0.0")
     }
 }


### PR DESCRIPTION
Some users are getting vulnerability alerts due to an older version of spring security. This PR fixes that 