### PR TITLE
chore: bump Spring Boot to 4.0.7 and pin embedded Tomcat to 11.0.24

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.21")
     implementation("org.jetbrains.kotlin:kotlin-allopen:2.3.21")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:4.0.6")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:4.0.7")
     implementation("io.spring.gradle:dependency-management-plugin:1.1.7")
     implementation("org.jmailen.gradle:kotlinter-gradle:5.3.0")
     implementation("pl.allegro.tech.build:axion-release-plugin:1.18.8")

--- a/buildSrc/src/main/kotlin/encore.spring-boot-app-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/encore.spring-boot-app-conventions.gradle.kts
@@ -10,6 +10,17 @@ plugins {
 tasks.named<BootJar>("bootJar") {
     archiveClassifier.set("boot")
 }
+dependencyManagement {
+    // spring-boot-dependencies 4.0.7 pins tomcat 11.0.22; override for later CVE fixes (11.0.23/24)
+    overriddenByDependencies(false)
+    dependencies {
+        dependencySet("org.apache.tomcat.embed:11.0.24") {
+            entry("tomcat-embed-core")
+            entry("tomcat-embed-el")
+            entry("tomcat-embed-websocket")
+        }
+    }
+}
 graalvmNative {
     binaries {
         named("main") {


### PR DESCRIPTION
## Summary
- Bumps `spring-boot-gradle-plugin` from 4.0.6 to 4.0.7
- Pins `org.apache.tomcat.embed:*` explicitly to 11.0.24 (the latest available on Maven Central) via `dependencyManagement`, since Spring Boot 4.0.7's BOM only manages Tomcat up to 11.0.22

Tomcat 11.0.21 (the version pulled in transitively on Spring Boot 4.0.6) was affected by 16 known CVEs, most notably:
- **CVE-2026-43512** (Moderate) — DIGEST auth would authenticate any unknown user presenting password `"null"`
- **CVE-2026-43515** (Moderate) — multiple security constraints on the same extension pattern only applied the first HTTP method constraint
- **CVE-2026-55956** (Moderate) — security constraints on the default servlet ignored method restrictions

This brings the embedded Tomcat to 11.0.24, resolving 15 of the 16 CVEs. The one remaining (CVE-2026-66299, Low severity, fixed in 11.0.25) is a DoS in the Tomcat WebSocket *chat example* webapp, not part of the embedded runtime Spring Boot ships, and 11.0.25 isn't yet published to Maven Central.

## Test plan
- [x] `./gradlew :encore-web:dependencies --configuration runtimeClasspath` confirms resolution to `tomcat-embed-core:11.0.24`
- [x] `./gradlew :encore-web:test` passes, including a live Tomcat start/graceful-shutdown cycle in the logs
- [x] Confirmed the pre-existing `jacocoTestCoverageVerification` failure on `encore-common` is unrelated and present on `release` without this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)